### PR TITLE
Fix problem when `type java`  does not find java

### DIFF
--- a/zowe-api-dev/src/commands/init.ts
+++ b/zowe-api-dev/src/commands/init.ts
@@ -100,7 +100,7 @@ function stripTrailingSlash(path: string): string {
 
 function detectJavaHome(command: Command): string | null {
     const candidates = ["/sys/java64bt/v8r0m0/usr/lpp/java/J8.0_64", "/usr/lpp/java/J8.0_64"];
-    const type = execSshCommandWithDefaultEnvCwd("type java").stdout.trim();
+    const type = execSshCommandWithDefaultEnvCwd("type java", { throwError: false }).stdout.trim();
     const javaIs = "java is /";
     const javaIsIndex = type.indexOf(javaIs);
     if (javaIsIndex > -1) {


### PR DESCRIPTION
Fix for a problem reported by @dkelosky:
 
![unnamed](https://user-images.githubusercontent.com/7644758/64533692-54619a00-d314-11e9-9469-5019e3d86e4a.png)

Signed-off-by: Petr Plavjanik <plavjanik@gmail.com>