### PR TITLE
Show a good error message when Zowe CLI does not return output for USS commands

### DIFF
--- a/zowe-api-dev/src/commands/init.ts
+++ b/zowe-api-dev/src/commands/init.ts
@@ -113,7 +113,13 @@ function stripTrailingSlash(path: string): string {
 
 function detectJavaHome(command: Command): string | null {
     const candidates = ["/sys/java64bt/v8r0m0/usr/lpp/java/J8.0_64", "/usr/lpp/java/J8.0_64"];
-    const type = execSshCommandWithDefaultEnvCwd("type java", { throwError: false }).stdout.trim();
+    const typeResult = execSshCommandWithDefaultEnvCwd("type java", { throwError: false });
+    if (!typeResult.success && !typeResult.stdout) {
+        zoweSync("profiles list ssh-profiles --show-contents");
+        command.log(logSymbols.error, "The Zowe CLI has returned no output for a z/OS UNIX command. Check the port in your Zowe ssh profile. The typical SSH port is 22.");
+        command.exit(1);
+    }
+    const type = typeResult.stdout.trim();
     const javaIs = "java is /";
     const javaIsIndex = type.indexOf(javaIs);
     if (javaIsIndex > -1) {

--- a/zowe-api-dev/src/zowe.ts
+++ b/zowe-api-dev/src/zowe.ts
@@ -32,6 +32,9 @@ export function zoweSync(command: string, options?: IZoweOptions): IZoweResult {
         debug(command);
         if (!direct) {
             const json: string = execSync(`zowe --rfj ${command}`, { encoding: "utf8" });
+            if (!json) {
+                throw { stdout: "" }
+            }
             const result: IZoweResult = JSON.parse(json);
             debug(result);
             if (logOutput) {
@@ -46,7 +49,12 @@ export function zoweSync(command: string, options?: IZoweOptions): IZoweResult {
         debug(error);
         let result: IZoweResult;
         try {
-            result = JSON.parse(error.stdout);
+            if (error.stdout) {
+                result = JSON.parse(error.stdout);
+            }
+            else {
+                result = { success: false, exitCode: -1, message: "empty JSON response from Zowe CLI", stderr: "", stdout: "", data: {} };
+            }
             debug(result);
         } catch (error2) {
             throw error;


### PR DESCRIPTION
This will handle the situation when `zowe uss issue ssh` does not return anything and print an actionable message.

This happens when the SSH port is set to a wrong port - e.g. 1443.

It is related to https://github.com/zowe/zowe-cli/issues/542.

Signed-off-by: Petr Plavjanik <plavjanik@gmail.com>