### PR TITLE
Make PUT requests working

### DIFF
--- a/zowe-rest-api-sample-spring/README.md
+++ b/zowe-rest-api-sample-spring/README.md
@@ -68,6 +68,7 @@ For further reference, please consider the following sections:
 - [z/OS Security](docs/zos-security.md)
 - [z/OS Native OS Linkage](docs/zos-native-os-linkage.md)
 - [Error Handling](docs/error-handling.md)
+- [Java Debugging](docs/java-debugging.md)
 
 ## Learn More about Gradle and Spring Boot
 

--- a/zowe-rest-api-sample-spring/config/local/application.yml
+++ b/zowe-rest-api-sample-spring/config/local/application.yml
@@ -3,6 +3,10 @@
 
 spring.profiles.active: https,diag
 
+logging:
+    level:
+        org.zowe.commons.zos.security: DEBUG
+
 server:
     address: 0.0.0.0
     port: 10080

--- a/zowe-rest-api-sample-spring/docs/java-debugging.md
+++ b/zowe-rest-api-sample-spring/docs/java-debugging.md
@@ -1,0 +1,9 @@
+# Java Debugging
+
+Option `-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=10081,suspend=n` will cause that the service will open a port for remote debugging. The server will start and work as usual. You can connect to the port 10081 from the remote debugger in your IDE.
+
+Example how to start the sample service with the debugging port:
+
+```bash
+java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=10081,suspend=n -jar build/libs/zowe-rest-api-sample-spring-*.jar --spring.config.additional-location=file:config/local/application.yml
+```

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/WebSecurityConfig.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/WebSecurityConfig.java
@@ -36,7 +36,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         http.httpBasic();
         http.authorizeRequests()
-                .antMatchers("/", "/error", "/swagger-ui.html", "/webjars/springfox-swagger-ui/**", "/apiDocs/**",
+                .antMatchers("/", "/swagger-ui.html", "/webjars/springfox-swagger-ui/**", "/apiDocs/**",
                         "/api/*/apiDocs", "/swagger-resources/**", "/csrf", "/actuator/info", "/actuator/health")
                 .permitAll().anyRequest().authenticated();
     }

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/WebSecurityConfig.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/WebSecurityConfig.java
@@ -30,13 +30,13 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
+        http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()).ignoringAntMatchers("/api/**");
         http.headers().httpStrictTransportSecurity().disable();
         http.exceptionHandling().authenticationEntryPoint(authenticationEntryPoint);
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         http.httpBasic();
         http.authorizeRequests()
-                .antMatchers("/", "/swagger-ui.html", "/webjars/springfox-swagger-ui/**", "/apiDocs/**",
+                .antMatchers("/", "/error", "/swagger-ui.html", "/webjars/springfox-swagger-ui/**", "/apiDocs/**",
                         "/api/*/apiDocs", "/swagger-resources/**", "/csrf", "/actuator/info", "/actuator/health")
                 .permitAll().anyRequest().authenticated();
     }

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingController.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingController.java
@@ -52,14 +52,14 @@ public class GreetingController {
         return new Greeting(counter.incrementAndGet(), String.format(template, greeting, name));
     }
 
-    @PutMapping
+    @PutMapping("settings")
     @ApiOperation(value = "Changes the default greeting word", nickname = "updateGreeting", authorizations = {
             @Authorization(value = DOC_SCHEME_BASIC_AUTH) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Successful settings change", response = Greeting.class),
             @ApiResponse(code = 400, message = "Invalid request parameter", response = ApiMessage.class) })
-    public Greeting updateGreeting(@RequestBody GreetingSettings settings) {
+    public GreetingSettings updateGreeting(@RequestBody GreetingSettings settings) {
         GreetingController.greeting = settings.getGreeting();
-        return getGreeting(DEFAULT_NAME);
+        return settings;
     }
 
     @ApiOperation(value = "This greeting always fails and provides example how unhandled exceptions are reported", nickname = "failedGreeting", authorizations = {

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingController.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingController.java
@@ -16,6 +16,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.ca.mfaas.rest.response.ApiMessage;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,29 +25,41 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.Authorization;
-import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
 
 @Api(tags = "Greeting", description = "REST API for greetings")
 @RestController
 @RequestMapping("/api/v1/greeting")
 public class GreetingController {
+    private static final String DEFAULT_NAME = "world";
+    private static final String template = "%s, %s!";
 
-    private static final String template = "Hello, %s!";
+    private static String greeting = "Hello";
     private final AtomicLong counter = new AtomicLong();
 
     @GetMapping
-    @ApiOperation(value = "Returns a greeting for the name passed", nickname = "greetingToSomeone", authorizations = {
+    @ApiOperation(value = "Returns a greeting for the name passed", nickname = "getGreeting", authorizations = {
             @Authorization(value = DOC_SCHEME_BASIC_AUTH) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Successful greeting", response = Greeting.class),
             @ApiResponse(code = 400, message = "Invalid request parameter - empty name", response = ApiMessage.class) })
-    public Greeting greeting(
-            @ApiParam(value = "Person or object to be greeted", required = false) @RequestParam(value = "name", defaultValue = "world") String name) {
+    public Greeting getGreeting(
+            @ApiParam(value = "Person or object to be greeted", required = false) @RequestParam(value = "name", defaultValue = DEFAULT_NAME) String name) {
         if (name.trim().isEmpty()) {
             throw new EmptyNameError();
         }
-        return new Greeting(counter.incrementAndGet(), String.format(template, name));
+        return new Greeting(counter.incrementAndGet(), String.format(template, greeting, name));
+    }
+
+    @PutMapping
+    @ApiOperation(value = "Changes the default greeting word", nickname = "updateGreeting", authorizations = {
+            @Authorization(value = DOC_SCHEME_BASIC_AUTH) })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Successful settings change", response = Greeting.class),
+            @ApiResponse(code = 400, message = "Invalid request parameter", response = ApiMessage.class) })
+    public Greeting updateGreeting(@RequestBody GreetingSettings settings) {
+        GreetingController.greeting = settings.getGreeting();
+        return getGreeting(DEFAULT_NAME);
     }
 
     @ApiOperation(value = "This greeting always fails and provides example how unhandled exceptions are reported", nickname = "failedGreeting", authorizations = {

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingSettings.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingSettings.java
@@ -1,0 +1,21 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.sample.apiservice.greeting;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class GreetingSettings {
+    @ApiModelProperty(value = "The greeting message without the name")
+    private String greeting;
+}

--- a/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/greeting/GreetingControllerTests.java
+++ b/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/greeting/GreetingControllerTests.java
@@ -13,9 +13,12 @@ import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,5 +67,14 @@ public class GreetingControllerTests {
     public void exceptionCausesFailure() throws Exception {
         mvc.perform(get("/api/v1/greeting/failed").header("Authorization", TestUtils.ZOWE_BASIC_AUTHENTICATION)
                 .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void settingsCanBeUpdated() throws Exception {
+        GreetingSettings settings = new GreetingSettings();
+        ObjectMapper mapper = new ObjectMapper();
+        settings.setGreeting("Hi");
+        mvc.perform(put("/api/v1/greeting/settings").header("Authorization", TestUtils.ZOWE_BASIC_AUTHENTICATION)
+                .contentType(MediaType.APPLICATION_JSON).content(mapper.writeValueAsString(settings))).andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
These changes make PUT requests working:

1. CSRF is disabled for the API request. It is still enabled for other endpoints.
2. A sample PUT request is added to GreetingController
   - A very difficult problem is that the class that is in `@RequestBody` need to allow setters for all fields and `@NoArgsConstructor` otherwise requests will fail with 400
3. A short guide on Java debugging has been added

Signed-off-by: Petr Plavjanik <plavjanik@gmail.com>