### PR TITLE
Support for additional fields in the error message format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
       - checkout
       - restore_cache: &keys
           keys:
-            - v1-zowe-sdk-{{ .Branch }}
-            - v1-zowe-sdk-master
+            - v2-zowe-sdk-{{ .Branch }}
+            - v2-zowe-sdk-master
       - run: &build_jarpatcher
           name: Building JAR Patcher using Gradle
           command: ./gradlew :jarpatcher:build
@@ -65,7 +65,7 @@ jobs:
             - ~/code/zowe-api-dev/node_modules
             - ~/code/zowe-rest-api-sample-spring/.gradle
             - ~/code/gradle/wrapper/gradle-wrapper.jar
-          key: v1-zowe-sdk-{{ .Branch }}-{{ epoch }}
+          key: v2-zowe-sdk-{{ .Branch }}-{{ epoch }}
   publish_all:
     docker:
       - image: circleci/openjdk:8-jdk-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
       - run: &zosbuild
           name: Building Native z/OS Code
           command: |
+            npm uninstall zowe-api-dev
             npm install
             source .circleci/river.env
             npm run zosbuild

--- a/scripts/run-integration-tests-zos.sh
+++ b/scripts/run-integration-tests-zos.sh
@@ -2,7 +2,7 @@
 scripts/lock-port.sh
 
 cd zowe-rest-api-sample-spring
-zowe-api-dev deploy
+zowe-api-dev deploy --force
 zowe-api-dev config --name zos -p port=$TEST_PORT
 zowe-api-dev start --job
 

--- a/zowe-api-dev/src/commands/deploy.ts
+++ b/zowe-api-dev/src/commands/deploy.ts
@@ -8,7 +8,7 @@ export default class Deploy extends Command {
     static description = "deploy the API service artifacts to z/OS";
 
     static flags = {
-        force: flags.boolean({ char: "f", description: "forces full deployment even if there is not change" }),
+        force: flags.boolean({ char: "f", description: "forces full deployment even if there is not change", default: true }),
     };
 
     async run() {

--- a/zowe-api-dev/src/files.ts
+++ b/zowe-api-dev/src/files.ts
@@ -106,7 +106,7 @@ export function transferFiles(
             }
         }
         const postCommands: string[] = [];
-        if (soUpdated && options.postSoUpdateCommands) {
+        if ((soUpdated || force) && options.postSoUpdateCommands) {
             postCommands.push(...options.postSoUpdateCommands);
         }
         if (options.postCommands) {

--- a/zowe-api-dev/src/files.ts
+++ b/zowe-api-dev/src/files.ts
@@ -58,6 +58,7 @@ export function transferFiles(
     console.time("transferFile");
     checkZoweProfileName(userConfig);
     for (const [file, options] of Object.entries(files)) {
+        debug("options", options);
         const zosFile = `${zosTargetDir}/${options.target}`;
         const zosDir = dirname(zosFile);
         let soUpdated = true;
@@ -112,6 +113,7 @@ export function transferFiles(
         if (options.postCommands) {
             postCommands.push(...options.postCommands);
         }
+        debug("postCommands", postCommands);
         for (const postCommand of postCommands) {
             let finalCommand = postCommand;
             if (postCommand.startsWith("java") && userConfig.javaHome) {

--- a/zowe-rest-api-commons-spring/build.gradle
+++ b/zowe-rest-api-commons-spring/build.gradle
@@ -82,7 +82,7 @@ task zosbuild(type: Exec) {
     if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
         commandLine 'zowe-api-dev.cmd', 'zosbuild'
     } else {
-        commandLine 'zowe-api-dev', 'zosbuild'
+        commandLine 'npx', 'zowe-api-dev', 'zosbuild'
     }
 }
 

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorMessage.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorMessage.java
@@ -11,51 +11,23 @@ package org.zowe.commons.error;
 
 import org.zowe.commons.rest.response.MessageType;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ErrorMessage {
     private String key;
     private String number;
     private MessageType type;
     private String text;
-
-    public ErrorMessage() {
-    }
+    private String reason;
+    private String action;
+    private String component;
 
     public ErrorMessage(String key, String number, MessageType type, String text) {
-        this.key = key;
-        this.number = number;
-        this.type = type;
-        this.text = text;
-    }
-
-    public String getKey() {
-        return key;
-    }
-
-    public void setKey(String key) {
-        this.key = key;
-    }
-
-    public String getNumber() {
-        return number;
-    }
-
-    public void setNumber(String number) {
-        this.number = number;
-    }
-
-    public MessageType getType() {
-        return type;
-    }
-
-    public void setType(MessageType type) {
-        this.type = type;
-    }
-
-    public String getText() {
-        return text;
-    }
-
-    public void setText(String text) {
-        this.text = text;
+       this(key, number, type, text, null, null, null);
     }
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorService.java
@@ -9,9 +9,9 @@
  */
 package org.zowe.commons.error;
 
-import org.zowe.commons.rest.response.ApiMessage;
-
 import java.util.List;
+
+import org.zowe.commons.rest.response.ApiMessage;
 
 /**
  * Service for creating {@link ApiMessage} by string key and list of parameters.
@@ -56,4 +56,19 @@ public interface ErrorService {
      * @return Readable text for the given message key.
      */
     String getReadableMessage(String key, Object... parameters);
+
+    /**
+     * @return Returns the value of the default message source attribute that is
+     *         added to every error message. It is a string that identifies the
+     *         source service. For example: myhost:8080:serviceid
+     */
+    String getDefaultMessageSource();
+
+    /**
+     * @param defaultMessageSource The value of the default message source attribute
+     *                             that is added to every error message. It is a
+     *                             string that identifies the source service. For
+     *                             example: myhost:8080:serviceid
+     */
+    void setDefaultMessageSource(String defaultMessageSource);
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorServiceImpl.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorServiceImpl.java
@@ -36,6 +36,7 @@ public class ErrorServiceImpl implements ErrorService {
     private static final String INVALID_KEY_MESSAGE = "org.zowe.commons.error.invalidMessageKey";
     private static final String INVALID_MESSAGE_TEXT_FORMAT = "org.zowe.commons.error.invalidMessageTextFormat";
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorServiceImpl.class);
+    private static final int STACK_TRACE_ELEMENT_ABOVE_CREATEAPIMESSAGE_METHOD = 3;
 
     private final ErrorMessageStorage messageStorage;
     private String defaultMessageSource;
@@ -138,7 +139,7 @@ public class ErrorServiceImpl implements ErrorService {
         }
         if (message.getComponent() == null) {
             StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-            String className = stackTrace[3].getClassName();
+            String className = stackTrace[STACK_TRACE_ELEMENT_ABOVE_CREATEAPIMESSAGE_METHOD].getClassName();
             message.setComponent(className);
         }
         return new BasicMessage(message.getType(), message.getNumber(), text, message.getReason(), message.getAction(),

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/BasicMessage.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/BasicMessage.java
@@ -9,14 +9,13 @@
  */
 package org.zowe.commons.rest.response;
 
-import org.zowe.commons.rest.response.Message;
-import org.zowe.commons.rest.response.MessageType;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * Holds information about a {@link Message}. This class is immutable.
@@ -32,6 +31,7 @@ import java.util.UUID;
  *
  * @author Greg Berres, Petr Plavjanik
  */
+@JsonPropertyOrder({ "messageType", "messageNumber", "messageContent", "messageReason", "messageAction", "messageKey", "messageParameters", "messageInstanceId", "messageComponent", "messageSource"})
 public class BasicMessage implements Message {
     private final MessageType messageType;
     private final String messageNumber;
@@ -80,7 +80,7 @@ public class BasicMessage implements Message {
         this(messageType, messageNumber, messageContent, null, null, messageKey, null, generateMessageInstanceId(), null, null);
     }
 
-    private static String generateMessageInstanceId() {
+    public static String generateMessageInstanceId() {
         return UUID.randomUUID().toString();
     }
 

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/DefaultMessageSource.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/DefaultMessageSource.java
@@ -1,0 +1,51 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.commons.spring;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.zowe.commons.error.CommonsErrorService;
+import org.zowe.commons.error.ErrorService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@Slf4j
+public class DefaultMessageSource implements ApplicationListener<ApplicationReadyEvent> {
+    private final Environment environment;
+    private final ErrorService errorService;
+
+    @Autowired
+    public DefaultMessageSource(ErrorService errorService, Environment environment) {
+        this.errorService = errorService;
+        this.environment = environment;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        String hostname;
+        try {
+            hostname = InetAddress.getLocalHost().getCanonicalHostName();
+        } catch (UnknownHostException e) {
+            log.warn("Could not obtain hostname", e);
+            hostname = "?";
+        }
+        String serviceId = environment.getProperty("apiml.service.serviceId");
+        String messageSource = String.format("%s:%s:%s", hostname, environment.getProperty("server.port"), serviceId);
+        errorService.setDefaultMessageSource(messageSource);
+        CommonsErrorService.get().setDefaultMessageSource(messageSource);
+    }
+}

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/ServiceStartupEventHandler.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/ServiceStartupEventHandler.java
@@ -10,14 +10,8 @@
 package org.zowe.commons.spring;
 
 import java.lang.management.ManagementFactory;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
-import org.zowe.commons.error.CommonsErrorService;
-import org.zowe.commons.error.ErrorService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,30 +20,10 @@ import lombok.extern.slf4j.Slf4j;
 public class ServiceStartupEventHandler {
     public static int DEFAULT_DELAY_FACTOR = 5;
 
-    @Autowired
-    private Environment environment;
-
     public void onServiceStartup(String serviceName, int delayFactor) {
         long uptime = ManagementFactory.getRuntimeMXBean().getUptime();
         log.info("{} has been started in {} seconds", serviceName, uptime / 1000.0);
 
         new java.util.Timer().schedule(new EnableEurekaLoggingTimerTask(), uptime * DEFAULT_DELAY_FACTOR);
-
-        setDefaultErrorMessageSource();
-    }
-
-    private void setDefaultErrorMessageSource() {
-        ErrorService errorService = SpringContext.getBean(ErrorService.class);
-        String hostname;
-        try {
-            hostname = InetAddress.getLocalHost().getCanonicalHostName();
-        } catch (UnknownHostException e) {
-            log.warn("Could not obtain hostname", e);
-            hostname = "?";
-        }
-        String serviceId = environment.getProperty("apiml.service.serviceId");
-        String messageSource = String.format("%s:%s:%s", hostname, environment.getProperty("server.port"), serviceId);
-        errorService.setDefaultMessageSource(messageSource);
-        CommonsErrorService.get().setDefaultMessageSource(messageSource);
     }
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/ServiceStartupEventHandler.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/ServiceStartupEventHandler.java
@@ -10,8 +10,14 @@
 package org.zowe.commons.spring;
 
 import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+import org.zowe.commons.error.CommonsErrorService;
+import org.zowe.commons.error.ErrorService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,10 +26,30 @@ import lombok.extern.slf4j.Slf4j;
 public class ServiceStartupEventHandler {
     public static int DEFAULT_DELAY_FACTOR = 5;
 
+    @Autowired
+    private Environment environment;
+
     public void onServiceStartup(String serviceName, int delayFactor) {
         long uptime = ManagementFactory.getRuntimeMXBean().getUptime();
         log.info("{} has been started in {} seconds", serviceName, uptime / 1000.0);
 
         new java.util.Timer().schedule(new EnableEurekaLoggingTimerTask(), uptime * DEFAULT_DELAY_FACTOR);
+
+        setDefaultErrorMessageSource();
+    }
+
+    private void setDefaultErrorMessageSource() {
+        ErrorService errorService = SpringContext.getBean(ErrorService.class);
+        String hostname;
+        try {
+            hostname = InetAddress.getLocalHost().getCanonicalHostName();
+        } catch (UnknownHostException e) {
+            log.warn("Could not obtain hostname", e);
+            hostname = "?";
+        }
+        String serviceId = environment.getProperty("apiml.service.serviceId");
+        String messageSource = String.format("%s:%s:%s", hostname, environment.getProperty("server.port"), serviceId);
+        errorService.setDefaultMessageSource(messageSource);
+        CommonsErrorService.get().setDefaultMessageSource(messageSource);
     }
 }

--- a/zowe-rest-api-commons-spring/src/main/resources/commons-messages.yml
+++ b/zowe-rest-api-commons-spring/src/main/resources/commons-messages.yml
@@ -4,6 +4,8 @@ messages:
     number: ZWEAS001
     type: ERROR
     text: "Internal error: Invalid message key '%s' is provided. Please contact support for further assistance."
+    reason: "This is an internal error. The product tried to access message with a key that is not defined."
+    action: "Please contact support for further assistance."
 
   - key: org.zowe.commons.error.invalidMessageTextFormat
     number: ZWEAS002
@@ -37,11 +39,15 @@ messages:
     number: ZWEAS401
     type: ERROR
     text: "The request has not been applied because it lacks valid authentication credentials for the target resource: %s"
+    reason: "The accessed resource requires authentication. The request is missing valid authentication credentials."
+    action: "Review the product documentation for more details about acceptable authentication. Verify that your credentials are valid and contact security administrator to obtain valid credentials."
 
   - key: org.zowe.commons.rest.forbidden
     number: ZWEAS403
     type: ERROR
     text: "The user is not authorized to the target resource: %s"
+    reason: "The service has accepted the authentication of the user but the user does not have access right to the resource."
+    action: "Contact your security administrator to give you access."
 
   - key: org.zowe.commons.rest.methodNotAllowed
     number: ZWEAS405
@@ -62,6 +68,8 @@ messages:
     number: ZWEAS491
     type: ERROR
     text: "The password for the specified identity has expired."
+    reason: "The provided credentials are not invalid but the password is expired."
+    action: "Refer to the product documentation to see how to change your password."
 
   - key: org.zowe.commons.rest.internalServerError
     number: ZWEAS500

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorServiceImplTest.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorServiceImplTest.java
@@ -14,10 +14,8 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.zowe.commons.error.ErrorService;
-import org.zowe.commons.rest.response.ApiMessage;
-
 import org.junit.Test;
+import org.zowe.commons.rest.response.ApiMessage;
 
 public class ErrorServiceImplTest {
     private final ErrorService errorService = new ErrorServiceImpl();
@@ -37,6 +35,28 @@ public class ErrorServiceImplTest {
         ApiMessage message = errorService.createApiMessage("org.zowe.commons.rest.unsupportedMediaType");
 
         assertEquals("ZWEAS415", message.getMessages().get(0).getMessageNumber());
+    }
+
+    @Test
+    public void validDefaultMessageComponent() {
+        ApiMessage message = errorService.createApiMessage("org.zowe.commons.rest.unsupportedMediaType");
+
+        assertEquals("org.zowe.commons.error.ErrorServiceImplTest", message.getMessages().get(0).getMessageComponent());
+    }
+
+    @Test
+    public void validMessageComponent() {
+        ErrorService errorServiceFromFile = new ErrorServiceImpl("/test-messages.yml");
+        ApiMessage message = errorServiceFromFile.createApiMessage("org.zowe.commons.test.component");
+        assertEquals("zowe.sdk.commons.test", message.getMessages().get(0).getMessageComponent());
+    }
+
+    @Test
+    public void validMessageSource() {
+        ErrorService errorServiceFromFile = new ErrorServiceImpl("/test-messages.yml");
+        errorServiceFromFile.setDefaultMessageSource("host:port:service");
+        ApiMessage message = errorServiceFromFile.createApiMessage("org.zowe.commons.test.noArguments");
+        assertEquals("host:port:service", message.getMessages().get(0).getMessageSource());
     }
 
     @Test
@@ -84,5 +104,25 @@ public class ErrorServiceImplTest {
     public void constructorWithDuplicatedMessages() {
         errorService.loadMessages("/test-duplicate-messages.yml");
         errorService.createApiMessage("org.zowe.commons.test.noArguments");
+    }
+
+    @Test
+    public void messageWithReason() {
+        ErrorService errorServiceFromFile = new ErrorServiceImpl("/test-messages.yml");
+
+        ApiMessage message = errorServiceFromFile.createApiMessage("org.zowe.commons.test.reason");
+
+        assertEquals("CSC0002", message.getMessages().get(0).getMessageNumber());
+        assertEquals("Reason", message.getMessages().get(0).getMessageReason());
+    }
+
+    @Test
+    public void messageWithAction() {
+        ErrorService errorServiceFromFile = new ErrorServiceImpl("/test-messages.yml");
+
+        ApiMessage message = errorServiceFromFile.createApiMessage("org.zowe.commons.test.action");
+
+        assertEquals("CSC0003", message.getMessages().get(0).getMessageNumber());
+        assertEquals("Action", message.getMessages().get(0).getMessageAction());
     }
 }

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/DefaultMessageSourceTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/DefaultMessageSourceTests.java
@@ -1,0 +1,25 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.commons.spring;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.springframework.mock.env.MockEnvironment;
+import org.zowe.commons.error.CommonsErrorService;
+
+public class DefaultMessageSourceTests {
+    @Test
+    public void enableEurekaLoggingTimerTaskDoesNotFails() {
+        DefaultMessageSource defaultMessageSource = new DefaultMessageSource(CommonsErrorService.get(), new MockEnvironment().withProperty("apiml.service.serviceId", "testservice").withProperty("server.port", "1234"));
+        defaultMessageSource.onApplicationEvent(null);
+        assertTrue(CommonsErrorService.get().getDefaultMessageSource().endsWith(":1234:testservice"));
+    }
+}

--- a/zowe-rest-api-commons-spring/src/test/resources/test-messages.yml
+++ b/zowe-rest-api-commons-spring/src/test/resources/test-messages.yml
@@ -8,3 +8,28 @@ messages:
       number: TST0001
       type: INFO
       text: "Test message - expects decimal number %d"
+
+    - key: org.zowe.commons.test.reason
+      number: CSC0002
+      type: ERROR
+      text: "No arguments message"
+      reason: Reason
+
+    - key: org.zowe.commons.test.action
+      number: CSC0003
+      type: ERROR
+      text: "No arguments message"
+      action: Action
+
+    - key: org.zowe.commons.test.reasonAndAction
+      number: CSC0004
+      type: ERROR
+      text: "No arguments message"
+      reason: Reason
+      action: Action
+
+    - key: org.zowe.commons.test.component
+      number: CSC0005
+      type: ERROR
+      text: "No arguments message"
+      component: zowe.sdk.commons.test

--- a/zowe-rest-api-sample-spring/build.gradle
+++ b/zowe-rest-api-sample-spring/build.gradle
@@ -121,7 +121,7 @@ task zosbuild(type: Exec) {
     inputs.dir('zossrc').withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.cacheIf { true }
     outputs.file(sharedObjectFilePath)
-    commandLine 'zowe-api-dev', 'zosbuild'
+    commandLine 'npx', 'zowe-api-dev', 'zosbuild'
 }
 
 testlogger {

--- a/zowe-rest-api-sample-spring/docs/error-handling.md
+++ b/zowe-rest-api-sample-spring/docs/error-handling.md
@@ -9,6 +9,8 @@
     - [Defining New Numbered Message](#defining-new-numbered-message)
   - [Logging Numbered Message](#logging-numbered-message)
 
+See [Handling errors in a Zowe REST API](https://medium.com/zowe/handling-errors-in-a-zowe-rest-api-1719554ddd6) for explanation of the key concepts and steps how to handle errors in a REST API service.
+
 ## Handling Internal Errors
 
 Unexpected errors does not need to be handled or caught by your REST controller. If your controller throws an `Exception` or `RuntimeException` then Spring exception handler (customized by `CustomRestExceptionHandler` in the commons library) will convert the exception into a standardized format. For example request `https://localhost:10080/api/v1/exception` returns:

--- a/zowe-rest-api-sample-spring/docs/error-handling.md
+++ b/zowe-rest-api-sample-spring/docs/error-handling.md
@@ -90,6 +90,10 @@ Examples:
         {
             "fieldOne": "value",
             "someNumber": 1
+        },
+        {
+            "fieldOne": "another value",
+            "someNumber": 2
         }
     ]
     ```
@@ -127,7 +131,29 @@ Follow the principle that message key (for example `org.zowe.commons.apiml.servi
   - *messageParameters* - error message parameters. Used for formatting of localized messages.
   - *messageInstanceId* - unique ID of the message instance. Useful for locating of the message in the logs. The same ID should be printed in the log.
   - *messageComponent* - for support and developers - component that generated the error (can be fully qualified Java package or class name)
-  - *messageSource* - for support and developers - source service that generated the error (can Open Mainframe service name or host:port).Be sure to include as much useful data as possible and keep in mind different users of the message structure. However, be mindful not to leak data that should be kept private or implementation details to avoid breaches in security.
+  - *messageSource* - for support and developers - source service that generated the error. The SDK returns `host:port:serviceId` by default.
+
+Be sure to include as much useful data as possible and keep in mind different users of the message structure. However, be mindful not to leak data that should be kept private or implementation details to avoid breaches in security.
+
+**Example:**
+
+```json
+{
+  "messages": [
+    {
+      "messageType": "ERROR",
+      "messageNumber": "ZWEAS401",
+      "messageContent": "The request has not been applied because it lacks valid authentication credentials for the target resource: Full authentication is required to access this resource",
+      "messageReason": "The accessed resource requires authentication. The request is missing valid authentication credentials.",
+      "messageAction": "Review the product documentation for more details about acceptable authentication. Verify that your credentials are valid and contact security administrator to obtain valid credentials.",
+      "messageKey": "org.zowe.commons.rest.unauthorized",
+      "messageInstanceId": "d9ef6577-f66c-4845-988d-89fc3d993d72",
+      "messageComponent": "org.zowe.commons.spring.RestAuthenticationEntryPoint",
+      "messageSource": "usilca32.lvn.broadcom.net:10180:zowesample"
+    }
+  ]
+}
+```
 
 ### Defining New Numbered Message
 
@@ -141,6 +167,12 @@ Follow the principle that message key (for example `org.zowe.commons.apiml.servi
       type: ERROR
       text: "The provided name is empty. Provide a name that is not empty."
     ```
+
+**Notes:**
+
+- You can use optional `reason` and `action` properties to define `messageReason` and `messageActions`.
+- You can use `component` to override override the default compoment name which is the class name of the Java class that has created the message.
+- The `messageSource` is set automatically by the commons library to `hostname:port:serviceId`.
 
 ## Logging Numbered Message
 

--- a/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/security/SecurityContextControllerIntegrationTests.java
+++ b/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/security/SecurityContextControllerIntegrationTests.java
@@ -56,8 +56,10 @@ public class SecurityContextControllerIntegrationTests extends IntegrationTests 
         RestAssured.authentication = basic(VALID_USERID, EXPIRED_PASSWORD);
         when().get("/api/v1/securityTest/authenticatedUser").then().statusCode(401)
                 .body("messages[0].messageContent", containsString("expired"))
+                .body("messages[0].messageReason", containsString("missing valid authentication credentials"))
+                .body("messages[0].messageAction", containsString("contact security administrator"))
+                .body("messages[1].messageAction", containsString("change your password"))
                 .body("messages[1].messageKey", equalTo("org.zowe.commons.zos.security.authentication.error.expired"));
-
     }
 
     @Test

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/ApplicationConfig.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/ApplicationConfig.java
@@ -40,6 +40,5 @@ public class ApplicationConfig implements ApplicationListener<ApplicationReadyEv
     @Override
     public void onApplicationEvent(final ApplicationReadyEvent event) {
         serviceStartupEventHandler.onServiceStartup(serviceTitle, ServiceStartupEventHandler.DEFAULT_DELAY_FACTOR);
-        
     }
 }

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/ApplicationConfig.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/ApplicationConfig.java
@@ -9,9 +9,6 @@
  */
 package org.zowe.sample.apiservice.config;
 
-import org.zowe.commons.error.ErrorService;
-import org.zowe.commons.error.ErrorServiceImpl;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -19,6 +16,8 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.zowe.commons.error.ErrorService;
+import org.zowe.commons.error.ErrorServiceImpl;
 import org.zowe.commons.spring.ServiceStartupEventHandler;
 
 @Configuration
@@ -31,13 +30,16 @@ public class ApplicationConfig implements ApplicationListener<ApplicationReadyEv
     @Autowired
     private ServiceStartupEventHandler serviceStartupEventHandler;
 
+    private final ErrorService errorService = new ErrorServiceImpl("/messages.yml");
+
     @Bean
     public ErrorService errorService() {
-        return new ErrorServiceImpl("/messages.yml");
+        return errorService;
     }
 
     @Override
     public void onApplicationEvent(final ApplicationReadyEvent event) {
         serviceStartupEventHandler.onServiceStartup(serviceTitle, ServiceStartupEventHandler.DEFAULT_DELAY_FACTOR);
+        
     }
 }


### PR DESCRIPTION
- Support for reason and action fields in message YML format
- Support for component and source fields in error message format with default values that are assigned automatically
- The JSON format for the error message has the property ordering with more important fields first

Example:
```json
{
  "messages": [
    {
      "messageType": "ERROR",
      "messageNumber": "ZWEAS401",
      "messageContent": "The request has not been applied because it lacks valid authentication credentials for the target resource: Full authentication is required to access this resource",
      "messageReason": "The accessed resource requires authentication. The request is missing valid authentication credentials.",
      "messageAction": "Review the product documentation for more details about acceptable authentication. Verify that your credentials are valid and contact security administrator to obtain valid credentials.",
      "messageKey": "org.zowe.commons.rest.unauthorized",
      "messageInstanceId": "d9ef6577-f66c-4845-988d-89fc3d993d72",
      "messageComponent": "org.zowe.commons.spring.RestAuthenticationEntryPoint",
      "messageSource": "usilca32.lvn.broadcom.net:10180:zowesample"
    }
  ]
}
```

Signed-off-by: Petr Plavjanik <plavjanik@gmail.com>