### PR TITLE
i18n for REST APIs and error messages

### DIFF
--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/AccentStrippingPatternLayerEncoder.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/AccentStrippingPatternLayerEncoder.java
@@ -1,0 +1,44 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.commons;
+
+import java.text.Normalizer;
+
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Layout;
+import lombok.Setter;
+
+public class AccentStrippingPatternLayerEncoder extends PatternLayoutEncoder {
+    private static final String STRIP_ACCENTS_PROPERTY_NAME = "org.zowe.commons.logging.stripAccents";
+
+    @Setter
+    private boolean stripAccents = "true".equalsIgnoreCase(System.getProperty(STRIP_ACCENTS_PROPERTY_NAME));
+
+    @Override
+    public byte[] encode(ILoggingEvent event) {
+        String txt = layout.doLayout(event);
+        if (stripAccents) {
+            return stripAccents(txt).getBytes();
+        }
+        else {
+            return super.encode(event);
+        }
+    }
+
+    private String stripAccents(String input) {
+        return input == null ? null
+                : Normalizer.normalize(input, Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+    }
+
+    void overrideLayout(Layout layout) {
+        this.layout = layout;
+    }
+}

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/CommonsErrorService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/CommonsErrorService.java
@@ -13,7 +13,7 @@ import org.zowe.commons.error.ErrorService;
 import org.zowe.commons.error.ErrorServiceImpl;
 
 public final class CommonsErrorService {
-    private static ErrorService errorService = new ErrorServiceImpl();
+    private static ErrorService errorService = ErrorServiceImpl.getCommonsDefault();
 
     private CommonsErrorService() {
     }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorMessageStorage.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorMessageStorage.java
@@ -35,9 +35,11 @@ public class ErrorMessageStorage {
      * @param messages Error message
      */
     public void addMessages(ErrorMessages messages) {
+        Map<String, ErrorMessage> currentKeyMap = new HashMap<>();
         for (ErrorMessage message : messages.getMessages()) {
-            if (!keyMap.containsKey(message.getKey())) {
+            if (!currentKeyMap.containsKey(message.getKey())) {
                 if (!numberMap.containsKey(message.getNumber())) {
+                    currentKeyMap.put(message.getKey(), message);
                     keyMap.put(message.getKey(), message);
                     numberMap.put(message.getNumber(), message);
                 } else {

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorService.java
@@ -10,6 +10,7 @@
 package org.zowe.commons.error;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.zowe.commons.rest.response.ApiMessage;
 
@@ -19,12 +20,13 @@ import org.zowe.commons.rest.response.ApiMessage;
  */
 public interface ErrorService {
     /**
-     * Create {@link ApiMessage} that contains one
-     * {@link org.zowe.commons.rest.response.Message} for provided key with array of
+     * Create {@link ApiMessage} that contains list of
+     * {@link org.zowe.commons.rest.response.Message} with same key and provided
      * parameters.
      *
-     * @param key        of message in messages.yml file
-     * @param parameters for message
+     * @param key        Key of message in messages.yml file.
+     * @param parameters A list of parameters that will be used for formatting using
+     *                   {@link String.format}.
      * @return {@link ApiMessage} for key
      */
     ApiMessage createApiMessage(String key, Object... parameters);
@@ -34,25 +36,64 @@ public interface ErrorService {
      * {@link org.zowe.commons.rest.response.Message} with same key and provided
      * parameters.
      *
-     * @param key        of message in messages.yml file
-     * @param parameters list that contains arrays of parameters
+     * @param key        Key of message in messages.yml file.
+     * @param parameters A list that contains arrays of parameters that will be used
+     *                   for formatting using {@link String.format}.
      * @return {@link ApiMessage} for key
      */
     ApiMessage createApiMessage(String key, List<Object[]> parameters);
 
     /**
-     * Load messages to the context from the provided message file path
+     * Create {@link ApiMessage} that contains list of
+     * {@link org.zowe.commons.rest.response.Message} with same key and provided
+     * parameters.
      *
-     * @param messagesFilePath path of the message file
+     * @param locale     The locale that is used to retrieve the localized message.
+     *                   If it is null or message key is not found then the fallback
+     *                   is to use the US English message.
+     * @param key        Key of message in messages.yml file.
+     * @param parameters A list of parameters that will be used for formatting using
+     *                   {@link String.format}.
+     * @return {@link ApiMessage} for key
+     */
+    ApiMessage createApiMessage(Locale locale, String key, Object... parameters);
+
+    /**
+     * Create {@link ApiMessage} that contains list of
+     * {@link org.zowe.commons.rest.response.Message} with same key and provided
+     * parameters.
+     *
+     * @param locale     The locale that is used to retrieve the localized message.
+     *                   If it is null or message key is not found then the fallback
+     *                   is to use the US English message.
+     * @param key        Key of message in messages.yml file.
+     * @param parameters A list that contains arrays of parameters that will be used
+     *                   for formatting using {@link String.format}.
+     * @return {@link ApiMessage} for key
+     */
+    ApiMessage createApiMessage(Locale locale, String key, List<Object[]> parameters);
+
+    /**
+     * Loads messages to the context from the provided message file path.
+     *
+     * @param messagesFilePath Path of the message file resource.
      */
     void loadMessages(String messagesFilePath);
+
+    /**
+     * Loads localized messages from the provided resource bundle.
+     *
+     * @param baseName The base name of the resource bundle, a fully qualified class
+     *                 name.
+     */
+    void addResourceBundleBaseName(String baseName);
 
     /**
      * Returns the message in the format that can be printed to console as a single
      * line or displayed to the user.
      *
-     * @param key        Message key to be retrieved
-     * @param parameters Positional parameters require by the message
+     * @param key        Message key to be retrieved.
+     * @param parameters Positional parameters require by the message.
      * @return Readable text for the given message key.
      */
     String getReadableMessage(String key, Object... parameters);

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorService.java
@@ -25,8 +25,8 @@ public interface ErrorService {
      * parameters.
      *
      * @param key        Key of message in messages.yml file.
-     * @param parameters A list of parameters that will be used for formatting using
-     *                   {@link String.format}.
+     * @param parameters A list of parameters that will be used for formatting.
+     *
      * @return {@link ApiMessage} for key
      */
     ApiMessage createApiMessage(String key, Object... parameters);
@@ -38,7 +38,7 @@ public interface ErrorService {
      *
      * @param key        Key of message in messages.yml file.
      * @param parameters A list that contains arrays of parameters that will be used
-     *                   for formatting using {@link String.format}.
+     *                   for formatting.
      * @return {@link ApiMessage} for key
      */
     ApiMessage createApiMessage(String key, List<Object[]> parameters);
@@ -52,8 +52,7 @@ public interface ErrorService {
      *                   If it is null or message key is not found then the fallback
      *                   is to use the US English message.
      * @param key        Key of message in messages.yml file.
-     * @param parameters A list of parameters that will be used for formatting using
-     *                   {@link String.format}.
+     * @param parameters A list of parameters that will be used for formatting.
      * @return {@link ApiMessage} for key
      */
     ApiMessage createApiMessage(Locale locale, String key, Object... parameters);
@@ -68,7 +67,7 @@ public interface ErrorService {
      *                   is to use the US English message.
      * @param key        Key of message in messages.yml file.
      * @param parameters A list that contains arrays of parameters that will be used
-     *                   for formatting using {@link String.format}.
+     *                   for formatting.
      * @return {@link ApiMessage} for key
      */
     ApiMessage createApiMessage(Locale locale, String key, List<Object[]> parameters);

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorServiceImpl.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorServiceImpl.java
@@ -85,6 +85,7 @@ public class ErrorServiceImpl implements ErrorService {
     public static ErrorService getDefault() {
         ErrorServiceImpl errorService = new ErrorServiceImpl("/" + DEFAULT_MESSAGES_BASENAME + YAML_EXTENSION);
         errorService.addResourceBundleBaseName(DEFAULT_MESSAGES_BASENAME);
+        CommonsErrorService.get().addResourceBundleBaseName(DEFAULT_MESSAGES_BASENAME);
         return errorService;
     }
 
@@ -120,7 +121,9 @@ public class ErrorServiceImpl implements ErrorService {
 
     @Override
     public void addResourceBundleBaseName(String baseName) {
-        baseNames.add(baseName);
+        if (!baseNames.contains(baseName)) {
+            baseNames.add(baseName);
+        }
     }
 
     private ResourceBundle getResourceBundle(String baseName, Locale locale) {
@@ -143,8 +146,8 @@ public class ErrorServiceImpl implements ErrorService {
             localeMap.put(locale, bundle);
             return bundle;
         } catch (MissingResourceException ex) {
-            if (log.isWarnEnabled()) {
-                log.warn(String.format("ResourceBundle '%s' not found: %s", baseName, ex.getMessage()));
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("ResourceBundle '%s' not found: %s", baseName, ex.getMessage()));
             }
             return null;
         }
@@ -244,7 +247,8 @@ public class ErrorServiceImpl implements ErrorService {
 
     private String localizedText(Locale locale, String key, String defaultText) {
         if (locale != null) {
-            for (String baseName : baseNames) {
+            for (int i = baseNames.size() -1; i >= 0; i--) {
+                String baseName = baseNames.get(i);
                 ResourceBundle bundle = getResourceBundle(baseName, locale);
                 if (bundle == null) {
                     continue;

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorServiceImpl.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorServiceImpl.java
@@ -254,7 +254,7 @@ public class ErrorServiceImpl implements ErrorService {
                     continue;
                 }
                 try {
-                    return bundle.getString(key);
+                    return bundle.getString("messages." + key);
                 } catch (MissingResourceException ignored) {
                 }
             }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorServiceImpl.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorServiceImpl.java
@@ -11,10 +11,24 @@ package org.zowe.commons.error;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IllegalFormatConversionException;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
 import java.util.Objects;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -27,26 +41,67 @@ import org.zowe.commons.rest.response.BasicMessage;
 import org.zowe.commons.rest.response.Message;
 import org.zowe.commons.rest.response.MessageType;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
- * Default implementation of {@link ErrorService} that uses messages.yml as
- * source for messages.
+ * Default implementation of {@link ErrorService} that loads messages from YAML
+ * files.
  */
+@Slf4j
 public class ErrorServiceImpl implements ErrorService {
-    private static final String COMMONS_MESSAGES = "/commons-messages.yml";
+    private static final String COMMONS_MESSAGES_BASENAME = "commons-messages";
+    private static final String DEFAULT_MESSAGES_BASENAME = "messages";
+    private static final String YAML_EXTENSION = ".yml";
     private static final String INVALID_KEY_MESSAGE = "org.zowe.commons.error.invalidMessageKey";
     private static final String INVALID_MESSAGE_TEXT_FORMAT = "org.zowe.commons.error.invalidMessageTextFormat";
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorServiceImpl.class);
-    private static final int STACK_TRACE_ELEMENT_ABOVE_CREATEAPIMESSAGE_METHOD = 3;
+    private static final int STACK_TRACE_ELEMENT_ABOVE_CREATEAPIMESSAGE_METHOD = 4;
 
     private final ErrorMessageStorage messageStorage;
     private String defaultMessageSource;
+    private volatile ErrorServiceControl control = new ErrorServiceControl();
 
     /**
-     * Constructor that creates only common messages.
+     * Cache to hold loaded ResourceBundles. The key to this map is bundle basename
+     * which holds a Map which has the locale as the key and in turn holds the
+     * ResourceBundle instances.
+     */
+    private final Map<String, Map<Locale, ResourceBundle>> cachedResourceBundles = new ConcurrentHashMap<>();
+
+    /**
+     * List of base names that are used to load resource bundles for localized
+     * texts.
+     */
+    private final List<String> baseNames = new ArrayList<>(2);
+
+    /**
+     * Recommended way how to get an instance of ErrorService for your application.
+     *
+     * @return Error service that uses common messages and messages from default
+     *         resource file (messages.yml).
+     */
+    public static ErrorService getDefault() {
+        ErrorServiceImpl errorService = new ErrorServiceImpl("/" + DEFAULT_MESSAGES_BASENAME + YAML_EXTENSION);
+        errorService.addResourceBundleBaseName(DEFAULT_MESSAGES_BASENAME);
+        return errorService;
+    }
+
+    /**
+     * @return Returns an instance of error service with messages for the Zowe REST
+     *         API Commons.
+     */
+    public static ErrorService getCommonsDefault() {
+        ErrorServiceImpl errorService = new ErrorServiceImpl();
+        errorService.loadMessages("/" + COMMONS_MESSAGES_BASENAME + YAML_EXTENSION);
+        errorService.addResourceBundleBaseName(COMMONS_MESSAGES_BASENAME);
+        return errorService;
+    }
+
+    /**
+     * Constructor that creates empty message storage.
      */
     public ErrorServiceImpl() {
         messageStorage = new ErrorMessageStorage();
-        loadMessages(COMMONS_MESSAGES);
     }
 
     /**
@@ -56,44 +111,70 @@ public class ErrorServiceImpl implements ErrorService {
      */
     public ErrorServiceImpl(String messagesFilePath) {
         this();
+        loadMessages("/" + COMMONS_MESSAGES_BASENAME + YAML_EXTENSION);
+        addResourceBundleBaseName(COMMONS_MESSAGES_BASENAME);
         loadMessages(messagesFilePath);
     }
 
-    /**
-     * Creates {@link ApiMessage} with key and list of parameters.
-     *
-     * @param key        of message in messages.yml file
-     * @param parameters for message
-     * @return {@link ApiMessage}
-     */
+    @Override
+    public void addResourceBundleBaseName(String baseName) {
+        baseNames.add(baseName);
+    }
+
+    private ResourceBundle getResourceBundle(String baseName, Locale locale) {
+        Map<Locale, ResourceBundle> localeMap = this.cachedResourceBundles.get(baseName);
+        if (localeMap != null) {
+            ResourceBundle bundle = localeMap.get(locale);
+            if (bundle != null) {
+                return bundle;
+            }
+        }
+        try {
+            ResourceBundle bundle = ResourceBundle.getBundle(baseName, locale, control);
+            if (localeMap == null) {
+                localeMap = new ConcurrentHashMap<>();
+                Map<Locale, ResourceBundle> existing = this.cachedResourceBundles.putIfAbsent(baseName, localeMap);
+                if (existing != null) {
+                    localeMap = existing;
+                }
+            }
+            localeMap.put(locale, bundle);
+            return bundle;
+        } catch (MissingResourceException ex) {
+            if (log.isWarnEnabled()) {
+                log.warn(String.format("ResourceBundle '%s' not found: %s", baseName, ex.getMessage()));
+            }
+            return null;
+        }
+    }
+
     @Override
     public ApiMessage createApiMessage(String key, Object... parameters) {
-        Message message = createMessage(key, parameters);
+        Message message = createMessage(null, key, parameters);
         return new BasicApiMessage(Collections.singletonList(message));
     }
 
-    /**
-     * Creates {@link ApiMessage} with list of {@link Message}.
-     *
-     * @param key        of message in messages.yml file
-     * @param parameters list that contains arrays of parameters
-     * @return {@link ApiMessage}
-     */
+    @Override
+    public ApiMessage createApiMessage(Locale locale, String key, Object... parameters) {
+        Message message = createMessage(locale, key, parameters);
+        return new BasicApiMessage(Collections.singletonList(message));
+    }
+
     @Override
     public ApiMessage createApiMessage(String key, List<Object[]> parameters) {
-        List<Message> messageList = parameters.stream().filter(Objects::nonNull).map(ob -> createMessage(key, ob))
+        List<Message> messageList = parameters.stream().filter(Objects::nonNull).map(ob -> createMessage(null, key, ob))
                 .collect(Collectors.toList());
         return new BasicApiMessage(messageList);
     }
 
-    /**
-     * Load messages to the context from the provided message file path
-     *
-     * @param messagesFilePath path of the message file
-     * @throws MessageLoadException      when a message couldn't loaded or has wrong
-     *                                   definition
-     * @throws DuplicateMessageException when a message is already defined before
-     */
+    @Override
+    public ApiMessage createApiMessage(Locale locale, String key, List<Object[]> parameters) {
+        List<Message> messageList = parameters.stream().filter(Objects::nonNull)
+                .map(ob -> createMessage(locale, key, ob)).collect(Collectors.toList());
+        return new BasicApiMessage(messageList);
+    }
+
+    @Override
     public void loadMessages(String messagesFilePath) {
         try (InputStream in = ErrorServiceImpl.class.getResourceAsStream(messagesFilePath)) {
             Yaml yaml = new Yaml();
@@ -115,21 +196,14 @@ public class ErrorServiceImpl implements ErrorService {
         this.defaultMessageSource = defaultMessageSource;
     }
 
-    /**
-     * Internal method that call {@link ErrorMessageStorage} to get message by key.
-     *
-     * @param key        of message.
-     * @param parameters array of parameters for message.
-     * @return {@link Message} in mainframe format
-     */
-    private Message createMessage(String key, Object... parameters) {
+    private Message createMessage(Locale locale, String key, Object... parameters) {
         ErrorMessage message = messageStorage.getErrorMessage(key);
         message = validateMessage(message, key);
         Object[] messageParameters = validateParameters(message, key, parameters);
 
         String text;
         try {
-            text = String.format(message.getText(), messageParameters);
+            text = String.format(localizedText(locale, key + ".text", message.getText()), messageParameters);
         } catch (IllegalFormatConversionException exception) {
             LOGGER.debug("Internal error: Invalid message format was used", exception);
             message = messageStorage.getErrorMessage(INVALID_MESSAGE_TEXT_FORMAT);
@@ -137,24 +211,41 @@ public class ErrorServiceImpl implements ErrorService {
             messageParameters = validateParameters(message, key, parameters);
             text = String.format(message.getText(), messageParameters);
         }
-        if (message.getComponent() == null) {
-            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-            String className = stackTrace[STACK_TRACE_ELEMENT_ABOVE_CREATEAPIMESSAGE_METHOD].getClassName();
-            message.setComponent(className);
-        }
-        return new BasicMessage(message.getType(), message.getNumber(), text, message.getReason(), message.getAction(),
-                key, null, BasicMessage.generateMessageInstanceId(), defaultMessageSource, message.getComponent());
+        String component = getLocalizedComponentOrUseDefault(locale, key, message);
+        return new BasicMessage(message.getType(), message.getNumber(), text,
+                localizedText(locale, key + ".reason", message.getReason()),
+                localizedText(locale, key + ".action", message.getAction()), key, null,
+                BasicMessage.generateMessageInstanceId(), defaultMessageSource, component);
     }
 
-    /**
-     * Internal method that validates the message. When the message does not exist,
-     * the key {@value INVALID_KEY_MESSAGE} is used. When this message also does not
-     * exist, the new predefined message is created.
-     *
-     * @param message to be checked
-     * @param key     of message
-     * @return {@link ErrorMessage} in mainframe format
-     */
+    private String getLocalizedComponentOrUseDefault(Locale locale, String key, ErrorMessage message) {
+        String component = message.getComponent();
+        if (component == null) {
+            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            String className = stackTrace[STACK_TRACE_ELEMENT_ABOVE_CREATEAPIMESSAGE_METHOD].getClassName();
+            component = className;
+        } else {
+            component = localizedText(locale, key + ".component", component);
+        }
+        return component;
+    }
+
+    private String localizedText(Locale locale, String key, String defaultText) {
+        if (locale != null) {
+            for (String baseName : baseNames) {
+                ResourceBundle bundle = getResourceBundle(baseName, locale);
+                if (bundle == null) {
+                    continue;
+                }
+                try {
+                    return bundle.getString(key);
+                } catch (MissingResourceException ignored) {
+                }
+            }
+        }
+        return defaultText;
+    }
+
     private ErrorMessage validateMessage(ErrorMessage message, String key) {
         if (message == null) {
             LOGGER.debug("Invalid message key '{}' was used. Please resolve this problem.", key);
@@ -174,21 +265,62 @@ public class ErrorServiceImpl implements ErrorService {
         return createApiMessage(key, parameters).toReadableText();
     }
 
-    /**
-     * Internal method that modifies parameters when the original message key does
-     * not exist and the new error message to indicate this issue is being used.
-     *
-     * @param message    to be checked if the original message was invalid
-     * @param key        of the original message
-     * @param parameters of the original message
-     * @return modified parameters if the message was changed, otherwise parameters
-     *         remain unchanged
-     */
     private Object[] validateParameters(ErrorMessage message, String key, Object... parameters) {
         if (message.getKey().equals(INVALID_KEY_MESSAGE)) {
             return new Object[] { key };
         } else {
             return parameters;
+        }
+    }
+
+    /**
+     * Custom implementation of {@code ResourceBundle.Control}, adding support for
+     * UTF-8.
+     */
+    private class ErrorServiceControl extends ResourceBundle.Control {
+        protected ResourceBundle loadBundle(Reader reader) throws IOException {
+            return new PropertyResourceBundle(reader);
+        }
+
+        @Override
+        public ResourceBundle newBundle(String baseName, Locale locale, String format, ClassLoader loader,
+                boolean reload) throws IllegalAccessException, InstantiationException, IOException {
+            if (format.equals("java.properties")) {
+                String bundleName = toBundleName(baseName, locale);
+                String resourceName = toResourceName(bundleName, "properties");
+                ClassLoader classLoader = loader;
+                boolean reloadFlag = reload;
+                InputStream inputStream;
+                try {
+                    inputStream = AccessController.doPrivileged((PrivilegedExceptionAction<InputStream>) () -> {
+                        InputStream is = null;
+                        if (reloadFlag) {
+                            URL url = classLoader.getResource(resourceName);
+                            if (url != null) {
+                                URLConnection connection = url.openConnection();
+                                if (connection != null) {
+                                    connection.setUseCaches(false);
+                                    is = connection.getInputStream();
+                                }
+                            }
+                        } else {
+                            is = classLoader.getResourceAsStream(resourceName);
+                        }
+                        return is;
+                    });
+                } catch (PrivilegedActionException ex) {
+                    throw (IOException) ex.getException();
+                }
+                if (inputStream != null) {
+                    try (InputStreamReader bundleReader = new InputStreamReader(inputStream, "UTF-8")) {
+                        return loadBundle(bundleReader);
+                    }
+                } else {
+                    return null;
+                }
+            } else {
+                return super.newBundle(baseName, locale, format, loader, reload);
+            }
         }
     }
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/ApiMessage.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/ApiMessage.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * This interface is intended for REST API responses that contain error,
- * warning, or informational messages in the common MFaaS format.
+ * warning, or informational messages in the common Zowe format.
  *
  * It is preferred to return successful responses without messages if possible
  * and use only plain responses without wrapping for them.

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/Message.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/Message.java
@@ -30,9 +30,9 @@ public interface Message {
 
     /**
      * Typical mainframe message number (not including the message level one-letter
-     * code) that can be found in CA documentation. The message number is usually in
-     * this format "pppnnnn" where ppp is a product code and nnnn is a four-digit
-     * number.
+     * code) that can be found in typical mainframe documentation. The message
+     * number is usually in this format "pppnnnn" where ppp is a product code and
+     * nnnn is a four-digit number.
      *
      * Example: "PFI0031"
      */
@@ -81,15 +81,15 @@ public interface Message {
      * For support and developers - component that generated the error (can be fully
      * qualified Java package or class name). This field is optional.
      *
-     * Example: com.ca.product.package
+     * Example: org.zowe.service.package.Class
      */
     String getMessageComponent();
 
     /**
-     * For support and developers - source service that generated the error (can
-     * MFaaS service name or host:port). This field is optional.
+     * For support and developers - source service that generated the error (it can
+     * be a Zowe service name or host:port). This field is optional.
      *
-     * Example: mfaas-discovery-service, ca31:12345
+     * Example: river.zowe.org:1234:myservice
      */
     String getMessageSource();
 

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/CustomRestExceptionHandler.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/CustomRestExceptionHandler.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.commons.spring;
 
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -40,10 +41,14 @@ public class CustomRestExceptionHandler extends ResponseEntityExceptionHandler {
 
     private final ErrorService errorService = CommonsErrorService.get();
 
+    private ApiMessage localizedMessage(String key) {
+        return errorService.createApiMessage(LocaleContextHolder.getLocale(), key);
+    }
+
     @Override
     protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex,
             HttpHeaders headers, HttpStatus status, WebRequest request) {
-        ApiMessage message = errorService.createApiMessage("org.zowe.commons.rest.methodNotAllowed");
+        ApiMessage message = localizedMessage("org.zowe.commons.rest.methodNotAllowed");
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).contentType(MediaType.APPLICATION_JSON_UTF8)
                 .body(message);
     }
@@ -51,27 +56,28 @@ public class CustomRestExceptionHandler extends ResponseEntityExceptionHandler {
     @Override
     protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders headers,
             HttpStatus status, WebRequest request) {
-        ApiMessage message = errorService.createApiMessage("org.zowe.commons.rest.notFound");
+        ApiMessage message = localizedMessage("org.zowe.commons.rest.notFound");
         return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(MediaType.APPLICATION_JSON_UTF8).body(message);
     }
 
     @Override
     protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex,
             HttpHeaders headers, HttpStatus status, WebRequest request) {
-        ApiMessage message = errorService.createApiMessage("org.zowe.commons.rest.unsupportedMediaType");
+        ApiMessage message = localizedMessage("org.zowe.commons.rest.unsupportedMediaType");
         return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).contentType(MediaType.APPLICATION_JSON_UTF8)
                 .body(message);
     }
 
     @ExceptionHandler({ AccessDeniedException.class })
     public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex, WebRequest request) {
-        ApiMessage message = errorService.createApiMessage(FORBIDDEN_MESSAGE_KEY, ex.getMessage());
+        ApiMessage message = errorService.createApiMessage(LocaleContextHolder.getLocale(), FORBIDDEN_MESSAGE_KEY,
+                ex.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).contentType(MediaType.APPLICATION_JSON_UTF8).body(message);
     }
 
     @ExceptionHandler({ Exception.class })
     public ResponseEntity<Object> handleAll(Exception ex, WebRequest request) {
-        ApiMessage message = errorService.createApiMessage(INTERNAL_SERVER_ERROR_MESSAGE_KEY);
+        ApiMessage message = localizedMessage(INTERNAL_SERVER_ERROR_MESSAGE_KEY);
         log.error(message.toLogMessage(), ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).contentType(MediaType.APPLICATION_JSON_UTF8)
                 .body(message);

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/RestAuthenticationEntryPoint.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/RestAuthenticationEntryPoint.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -56,7 +57,7 @@ public final class RestAuthenticationEntryPoint implements AuthenticationEntryPo
             AuthenticationException authException) throws IOException, ServletException {
         HttpStatus httpStatus = HttpStatus.UNAUTHORIZED;
 
-        ApiMessage message = errorService.createApiMessage(UNAUTHORIZED_MESSAGE_KEY, authException.getMessage());
+        ApiMessage message = errorService.createApiMessage(LocaleContextHolder.getLocale(), UNAUTHORIZED_MESSAGE_KEY, authException.getMessage());
 
         PlatformReturned returned = (PlatformReturned) request
                 .getAttribute(ZosAuthenticationProvider.ZOWE_AUTHENTICATE_RETURNED);
@@ -64,18 +65,18 @@ public final class RestAuthenticationEntryPoint implements AuthenticationEntryPo
             PlatformPwdErrno errno = PlatformPwdErrno.valueOfErrno(returned.errno);
             if ((errno != null) && (errno.errorType == PlatformErrorType.INTERNAL)) {
                 httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-                message = errorService.createApiMessage(INTERNAL_AUTHENTICATION_ERROR_MESSAGE_KEY, errno.explanation);
+                message = errorService.createApiMessage(LocaleContextHolder.getLocale(), INTERNAL_AUTHENTICATION_ERROR_MESSAGE_KEY, errno.explanation);
                 log.error(message.toLogMessage()
                         + String.format(" Security error details: %s %s %s", errno.name, errno.explanation, returned));
             } else if ((errno != null) && (errno.errorType == PlatformErrorType.USER_EXPLAINED)) {
-                message = errorService.createApiMessage(UNAUTHORIZED_MESSAGE_KEY, errno.explanation);
-                ApiMessage expiredMessage = errorService.createApiMessage(EXPIRED_MESSAGE_KEY);
+                message = errorService.createApiMessage(LocaleContextHolder.getLocale(), UNAUTHORIZED_MESSAGE_KEY, errno.explanation);
+                ApiMessage expiredMessage = errorService.createApiMessage(LocaleContextHolder.getLocale(), EXPIRED_MESSAGE_KEY);
                 List<Message> messages = new ArrayList<>();
                 messages.add(message.getMessages().get(0));
                 messages.add(expiredMessage.getMessages().get(0));
                 message = new BasicApiMessage(messages);
             } else {
-                message = errorService.createApiMessage(UNAUTHORIZED_MESSAGE_KEY, "Incorrect credentials");
+                message = errorService.createApiMessage(LocaleContextHolder.getLocale(), UNAUTHORIZED_MESSAGE_KEY, "Incorrect credentials");
             }
         }
 

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/ServiceStartupEventHandler.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/ServiceStartupEventHandler.java
@@ -12,6 +12,7 @@ package org.zowe.commons.spring;
 import java.lang.management.ManagementFactory;
 
 import org.springframework.stereotype.Component;
+import org.zowe.commons.error.CommonsErrorService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -22,7 +23,7 @@ public class ServiceStartupEventHandler {
 
     public void onServiceStartup(String serviceName, int delayFactor) {
         long uptime = ManagementFactory.getRuntimeMXBean().getUptime();
-        log.info("{} has been started in {} seconds", serviceName, uptime / 1000.0);
+        log.info(CommonsErrorService.get().createApiMessage("org.zowe.commons.service.started", serviceName, uptime / 1000.0).toReadableText());
 
         new java.util.Timer().schedule(new EnableEurekaLoggingTimerTask(), uptime * DEFAULT_DELAY_FACTOR);
     }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/WebConfig.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/WebConfig.java
@@ -7,17 +7,41 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package org.zowe.sample.apiservice.config;
+package org.zowe.commons.spring;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.i18n.CookieLocaleResolver;
+import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+    private static final String LANG_PARAM_NAME = "lang";
+
+    @Bean
+    public LocaleChangeInterceptor localeInterceptor() {
+        LocaleChangeInterceptor localeInterceptor = new LocaleChangeInterceptor();
+        localeInterceptor.setParamName(LANG_PARAM_NAME);
+        return localeInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(localeInterceptor());
+    }
+
     public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
         configurer.favorPathExtension(true).favorParameter(false).ignoreAcceptHeader(true)
                 .useRegisteredExtensionsOnly(true).defaultContentType(MediaType.APPLICATION_JSON);
+    }
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        return new CookieLocaleResolver();
     }
 }

--- a/zowe-rest-api-commons-spring/src/main/resources/commons-messages.yml
+++ b/zowe-rest-api-commons-spring/src/main/resources/commons-messages.yml
@@ -1,5 +1,5 @@
 messages:
-  # Commons Internal Errors:
+  # Commons internal errors:
   - key: org.zowe.commons.error.invalidMessageKey
     number: ZWEAS001
     type: ERROR
@@ -16,6 +16,12 @@ messages:
     number: ZWEAS003
     type: ERROR
     text: "Internal authentication error: %s. Please contact support for further assistance."
+
+  # Service life-cycle:
+  - key: org.zowe.commons.service.started
+    number: ZWEAS101
+    type: INFO
+    text: "'%s' has been started in %.3f seconds"
 
   # API Mediation Layer integration:
   - key: org.zowe.commons.apiml.serviceCertificateNotTrusted

--- a/zowe-rest-api-commons-spring/src/main/resources/commons-messages_cs.properties
+++ b/zowe-rest-api-commons-spring/src/main/resources/commons-messages_cs.properties
@@ -13,3 +13,4 @@ org.zowe.commons.error.invalidMessageKey.reason=Toto je interní chyba. Produkt 
 org.zowe.commons.error.invalidMessageKey.action=Další pomoc vám poskytne technická podpora.
 
 org.zowe.commons.rest.notFound.text=Služba nemůže najít požadovaný zdroj.
+org.zowe.commons.service.started.text='%s' se spustila za %.3f sekund

--- a/zowe-rest-api-commons-spring/src/main/resources/commons-messages_cs.properties
+++ b/zowe-rest-api-commons-spring/src/main/resources/commons-messages_cs.properties
@@ -8,9 +8,9 @@
 # Copyright Contributors to the Zowe Project.
 #
 
-org.zowe.commons.error.invalidMessageKey.text=Interní chyba: Neplatný klíč zprávy '%s'. Další pomoc vám poskytne technická podpora.
-org.zowe.commons.error.invalidMessageKey.reason=Toto je interní chyba. Produkt se pokusil získat přístup ke zprávě pomocí klíče, který není definován.
-org.zowe.commons.error.invalidMessageKey.action=Další pomoc vám poskytne technická podpora.
+messages.org.zowe.commons.error.invalidMessageKey.text=Interní chyba: Neplatný klíč zprávy '%s'. Další pomoc vám poskytne technická podpora.
+messages.org.zowe.commons.error.invalidMessageKey.reason=Toto je interní chyba. Produkt se pokusil získat přístup ke zprávě pomocí klíče, který není definován.
+messages.org.zowe.commons.error.invalidMessageKey.action=Další pomoc vám poskytne technická podpora.
 
-org.zowe.commons.rest.notFound.text=Služba nemůže najít požadovaný zdroj.
-org.zowe.commons.service.started.text='%s' se spustila za %.3f sekund
+messages.org.zowe.commons.rest.notFound.text=Služba nemůže najít požadovaný zdroj.
+messages.org.zowe.commons.service.started.text='%s' se spustila za %.3f sekund

--- a/zowe-rest-api-commons-spring/src/main/resources/commons-messages_cs.properties
+++ b/zowe-rest-api-commons-spring/src/main/resources/commons-messages_cs.properties
@@ -1,0 +1,15 @@
+#
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+#
+
+org.zowe.commons.error.invalidMessageKey.text=Interní chyba: Neplatný klíč zprávy '%s'. Další pomoc vám poskytne technická podpora.
+org.zowe.commons.error.invalidMessageKey.reason=Toto je interní chyba. Produkt se pokusil získat přístup ke zprávě pomocí klíče, který není definován.
+org.zowe.commons.error.invalidMessageKey.action=Další pomoc vám poskytne technická podpora.
+
+org.zowe.commons.rest.notFound.text=Služba nemůže najít požadovaný zdroj.

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/AccentStrippingPatternLayerEncoderTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/AccentStrippingPatternLayerEncoderTests.java
@@ -1,0 +1,36 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.commons;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Layout;
+
+public class AccentStrippingPatternLayerEncoderTests {
+    @Test
+    public void testWrapRunnableInEnvironmentForAuthenticatedUser() {
+        AccentStrippingPatternLayerEncoder encoder = new AccentStrippingPatternLayerEncoder();
+        Layout<ILoggingEvent> layout = mock(Layout.class);
+        ILoggingEvent event = null;
+		when(layout.doLayout(event)).thenReturn("Příliš žluťoučký kůň úpěl ďábelské ódy");
+        encoder.overrideLayout(layout);
+        encoder.setStripAccents(true);
+        byte[] bytes = encoder.encode(event);
+        assertEquals("Prilis zlutoucky kun upel dabelske ody", new String(bytes));
+        encoder.setStripAccents(false);
+        byte[] bytes2 = encoder.encode(event);
+        assertEquals("Příliš žluťoučký kůň úpěl ďábelské ódy", new String(bytes2));
+    }
+}

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/CommonsErrorServiceTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/CommonsErrorServiceTests.java
@@ -11,6 +11,8 @@ package org.zowe.commons.error;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.Locale;
+
 import org.junit.Test;
 
 public class CommonsErrorServiceTests {
@@ -18,6 +20,13 @@ public class CommonsErrorServiceTests {
     public void returnsReadableMessage() {
         assertTrue(CommonsErrorService.get()
                 .getReadableMessage("org.zowe.commons.apiml.serviceCertificateNotTrusted", "param").contains("param"));
+    }
+
+    @Test
+    public void returnsLocalizedMessage() {
+        assertTrue(CommonsErrorService.get()
+                .createApiMessage(Locale.forLanguageTag("cs"), "org.zowe.commons.rest.notFound").getMessages().get(0)
+                .getMessageContent().contains("Služba"));
     }
 
 }

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorServiceImplTest.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorServiceImplTest.java
@@ -151,8 +151,4 @@ public class ErrorServiceImplTest {
         assertEquals("CSC0003", message.getMessages().get(0).getMessageNumber());
         assertEquals("Action", message.getMessages().get(0).getMessageAction());
     }
-
-    @Test
-    public void localeTest() {
-    }
 }

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorServiceImplTest.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorServiceImplTest.java
@@ -10,6 +10,7 @@
 package org.zowe.commons.error;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -127,6 +128,18 @@ public class ErrorServiceImplTest {
 
         assertEquals("CSC0002", message.getMessages().get(0).getMessageNumber());
         assertEquals("Reason", message.getMessages().get(0).getMessageReason());
+    }
+
+    @Test
+    public void messageWithReasonParameters() {
+        ErrorService errorServiceFromFile = new ErrorServiceImpl("/test-messages.yml");
+
+        ApiMessage message = errorServiceFromFile.createApiMessage("org.zowe.commons.test.parameters", "string", 123);
+
+        assertEquals("Test message - expects decimal number 123 and string",
+                message.getMessages().get(0).getMessageContent());
+        assertTrue(message.getMessages().get(0).getMessageParameters().contains(123));
+        assertTrue(message.getMessages().get(0).getMessageParameters().contains("string"));
     }
 
     @Test

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorServiceImplTest.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorServiceImplTest.java
@@ -13,12 +13,13 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.Test;
 import org.zowe.commons.rest.response.ApiMessage;
 
 public class ErrorServiceImplTest {
-    private final ErrorService errorService = new ErrorServiceImpl();
+    private final ErrorService errorService = ErrorServiceImpl.getCommonsDefault();
 
     @Test
     public void invalidMessageKey() {
@@ -49,6 +50,18 @@ public class ErrorServiceImplTest {
         ErrorService errorServiceFromFile = new ErrorServiceImpl("/test-messages.yml");
         ApiMessage message = errorServiceFromFile.createApiMessage("org.zowe.commons.test.component");
         assertEquals("zowe.sdk.commons.test", message.getMessages().get(0).getMessageComponent());
+    }
+
+    @Test
+    public void validLocalizedTexts() {
+        ErrorService errorServiceFromFile = new ErrorServiceImpl("/test-messages.yml");
+        errorServiceFromFile.addResourceBundleBaseName("test-messages");
+        ApiMessage message = errorServiceFromFile.createApiMessage(Locale.forLanguageTag("cs-CZ"),
+                "org.zowe.commons.test.localized");
+        assertEquals("Lokalizovaná zpráva", message.getMessages().get(0).getMessageContent());
+        assertEquals("Akce", message.getMessages().get(0).getMessageAction());
+        assertEquals("Důvod", message.getMessages().get(0).getMessageReason());
+        assertEquals("Komponenta", message.getMessages().get(0).getMessageComponent());
     }
 
     @Test
@@ -124,5 +137,9 @@ public class ErrorServiceImplTest {
 
         assertEquals("CSC0003", message.getMessages().get(0).getMessageNumber());
         assertEquals("Action", message.getMessages().get(0).getMessageAction());
+    }
+
+    @Test
+    public void localeTest() {
     }
 }

--- a/zowe-rest-api-commons-spring/src/test/resources/test-messages.yml
+++ b/zowe-rest-api-commons-spring/src/test/resources/test-messages.yml
@@ -1,41 +1,46 @@
 messages:
-    - key: org.zowe.commons.test.noArguments
-      number: CSC0001
-      type: ERROR
-      text: "No arguments message"
+  - key: org.zowe.commons.test.noArguments
+    number: CSC0001
+    type: ERROR
+    text: "No arguments message"
 
-    - key: org.zowe.commons.test.invalidParameterFormat
-      number: TST0001
-      type: INFO
-      text: "Test message - expects decimal number %d"
+  - key: org.zowe.commons.test.invalidParameterFormat
+    number: TST0001
+    type: INFO
+    text: "Test message - expects decimal number %d"
 
-    - key: org.zowe.commons.test.reason
-      number: CSC0002
-      type: ERROR
-      text: "No arguments message"
-      reason: Reason
+  - key: org.zowe.commons.test.reason
+    number: CSC0002
+    type: ERROR
+    text: "No arguments message"
+    reason: Reason
 
-    - key: org.zowe.commons.test.action
-      number: CSC0003
-      type: ERROR
-      text: "No arguments message"
-      action: Action
+  - key: org.zowe.commons.test.action
+    number: CSC0003
+    type: ERROR
+    text: "No arguments message"
+    action: Action
 
-    - key: org.zowe.commons.test.reasonAndAction
-      number: CSC0004
-      type: ERROR
-      text: "No arguments message"
-      reason: Reason
-      action: Action
+  - key: org.zowe.commons.test.reasonAndAction
+    number: CSC0004
+    type: ERROR
+    text: "No arguments message"
+    reason: Reason
+    action: Action
 
-    - key: org.zowe.commons.test.component
-      number: CSC0005
-      type: ERROR
-      text: "No arguments message"
-      component: zowe.sdk.commons.test
+  - key: org.zowe.commons.test.component
+    number: CSC0005
+    type: ERROR
+    text: "No arguments message"
+    component: zowe.sdk.commons.test
 
-    - key: org.zowe.commons.test.localized
-      number: CSC0006
-      type: INFO
-      text: "Localized message"
-      component: "Component"
+  - key: org.zowe.commons.test.localized
+    number: CSC0006
+    type: INFO
+    text: "Localized message"
+    component: "Component"
+
+  - key: org.zowe.commons.test.parameters
+    number: CSC0007
+    type: INFO
+    text: "Test message - expects decimal number %2$d and %1$s"

--- a/zowe-rest-api-commons-spring/src/test/resources/test-messages.yml
+++ b/zowe-rest-api-commons-spring/src/test/resources/test-messages.yml
@@ -33,3 +33,9 @@ messages:
       type: ERROR
       text: "No arguments message"
       component: zowe.sdk.commons.test
+
+    - key: org.zowe.commons.test.localized
+      number: CSC0006
+      type: INFO
+      text: "Localized message"
+      component: "Component"

--- a/zowe-rest-api-commons-spring/src/test/resources/test-messages_cs.properties
+++ b/zowe-rest-api-commons-spring/src/test/resources/test-messages_cs.properties
@@ -8,7 +8,7 @@
 # Copyright Contributors to the Zowe Project.
 #
 
-GreetingController.greeting=Ahoj
-GreetingController.greetingTemplate=%s, %s\!
-GreetingController.world=světe
-org.zowe.sample.apiservice.greeting.empty.text=Zadané jméno je prázdné. Zadejte jméno, které není prázdné.
+org.zowe.commons.test.localized.text: Lokalizovaná zpráva
+org.zowe.commons.test.localized.reason: Důvod
+org.zowe.commons.test.localized.action: Akce
+org.zowe.commons.test.localized.component: Komponenta

--- a/zowe-rest-api-commons-spring/src/test/resources/test-messages_cs.properties
+++ b/zowe-rest-api-commons-spring/src/test/resources/test-messages_cs.properties
@@ -8,7 +8,7 @@
 # Copyright Contributors to the Zowe Project.
 #
 
-org.zowe.commons.test.localized.text: Lokalizovaná zpráva
-org.zowe.commons.test.localized.reason: Důvod
-org.zowe.commons.test.localized.action: Akce
-org.zowe.commons.test.localized.component: Komponenta
+messages.org.zowe.commons.test.localized.text: Lokalizovaná zpráva
+messages.org.zowe.commons.test.localized.reason: Důvod
+messages.org.zowe.commons.test.localized.action: Akce
+messages.org.zowe.commons.test.localized.component: Komponenta

--- a/zowe-rest-api-sample-spring/docs/error-handling.md
+++ b/zowe-rest-api-sample-spring/docs/error-handling.md
@@ -9,6 +9,7 @@
     - [Defining New Numbered Message](#defining-new-numbered-message)
   - [Logging Numbered Message](#logging-numbered-message)
   - [Formatting Message Text](#formatting-message-text)
+  - [Overriding SDK Messages](#overriding-sdk-messages)
 
 See [Handling errors in a Zowe REST API](https://medium.com/zowe/handling-errors-in-a-zowe-rest-api-1719554ddd6) for explanation of the key concepts and steps how to handle errors in a REST API service.
 
@@ -225,3 +226,16 @@ The return code is X'0F'
 ```
 
 The [Formatter](https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html) uses C-style printf style of formatting. Refer to its documentation for more details.
+
+## Overriding SDK Messages
+
+Sometimes it can be helpful to override the message from the SDK. For example you would like to use your own message number or modify tbe text slightly.
+
+You are allowed to redefine the message key:
+
+```yaml
+    - key: org.zowe.commons.service.started
+      number: ZWEASA101
+      type: INFO
+      text: "'%s' has been started in %.3f seconds"
+```

--- a/zowe-rest-api-sample-spring/docs/error-handling.md
+++ b/zowe-rest-api-sample-spring/docs/error-handling.md
@@ -8,6 +8,7 @@
     - [Rules for Messages](#rules-for-messages)
     - [Defining New Numbered Message](#defining-new-numbered-message)
   - [Logging Numbered Message](#logging-numbered-message)
+  - [Formatting Message Text](#formatting-message-text)
 
 See [Handling errors in a Zowe REST API](https://medium.com/zowe/handling-errors-in-a-zowe-rest-api-1719554ddd6) for explanation of the key concepts and steps how to handle errors in a REST API service.
 
@@ -195,3 +196,32 @@ ApiMessage message = errorService.createApiMessage("message.key");
 log.info(message.toReadableText());
 // Prints: "INFO MSGNUM001I Message text"
 ```
+
+## Formatting Message Text
+
+The `ErrorServiceImpl` uses [Formatter](https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html) class and the arguments to format the message text. The formatter is using the provided locale or the default one.
+
+**Example:**
+
+We have a message defined like this:
+
+```yml
+key: formatted.message
+number: ZWEASA001
+type: INFO
+text: "The return code is X'%02X'"
+```
+
+Then this code:
+
+```java
+errorService.createApiMessage("formatted.message", 15).toReadableText();
+```
+
+Returns:
+
+```txt
+The return code is X'0F'
+```
+
+The [Formatter](https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html) uses C-style printf style of formatting. Refer to its documentation for more details.

--- a/zowe-rest-api-sample-spring/docs/error-handling.md
+++ b/zowe-rest-api-sample-spring/docs/error-handling.md
@@ -173,7 +173,7 @@ Be sure to include as much useful data as possible and keep in mind different us
 **Notes:**
 
 - You can use optional `reason` and `action` properties to define `messageReason` and `messageActions`.
-- You can use `component` to override override the default compoment name which is the class name of the Java class that has created the message.
+- You can use `component` to override override the default component name which is the class name of the Java class that has created the message.
 - The `messageSource` is set automatically by the commons library to `hostname:port:serviceId`.
 
 ## Logging Numbered Message

--- a/zowe-rest-api-sample-spring/docs/i18n.md
+++ b/zowe-rest-api-sample-spring/docs/i18n.md
@@ -211,3 +211,5 @@ export JZOS_OUTPUT_ENCODING="IBM-870"
 `JZOS_OUTPUT_ENCODING` causes JZOS batch launcher to convert the Unicode output from Java to IBM-870 when it is being written to a single-byte encoding in STDOUT DD. [IBM-870](https://en.wikipedia.org/wiki/EBCDIC_870) is the EBCDIC Latin-2 charset used in Czechia and other countries in Central Europe.
 
 Your terminal emulator needs to be set up to display IBM-870 correctly.
+
+This works well when Java is running as a job or STC via JZOS Batch Launcher. In other environments, the conversion setup can be difficult so there is `-Dorg.zowe.commons.logging.stripAccents=true` option that will strip accents.

--- a/zowe-rest-api-sample-spring/docs/i18n.md
+++ b/zowe-rest-api-sample-spring/docs/i18n.md
@@ -107,12 +107,81 @@ See [MessageSource](https://docs.spring.io/spring-framework/docs/current/javadoc
 
 ## Localizing the Standardized Error Messages
 
-TODO
+The `ApplicationConfig` class initializes the `errorService` bean.
+
+```java
+    private final ErrorService errorService = ErrorServiceImpl.getDefault();
+
+    @Bean
+    public ErrorService errorService() {
+        return errorService;
+    }
+```
+
+The `ErrorServiceImpl.getDefault()` creates an error service that load the SDK commons messages and your service messages from YAML files and their localizations from properties files. For your service `messages.yml` and `messages*.properties` are used.
+
+If you want to localize a text of a message defined in `messages.yml` you have to add the localized texts to the `messages*.properties`:
+
+```properties
+org.zowe.sample.apiservice.greeting.empty.text=Zadané jméno je prázdné. Zadejte jméno, které není prázdné.
+```
+
+Use the `{messageKey}.text` to define the message text for `{messageKey}`. You can use also the `.reason` and `.action` suffixes.
 
 ## Requesting a Specific Locale from API Client
 
-TODO
+The specific language or locale can be requested by `Accept-Language` HTTP header.
+
+The values depends on the locales that are supported by your service, for example:
+
+- `en` - English
+- `en-US` - English Enlish and US country
+- `cs` - Czech
+- `cs-CZ` - Czech and Czechia
+
+The fallback is to the message in the same language if there is not a message for specific country and to the default in unlabeled `messages.properties` or `messages.yaml` which are expected to be in `en-US`.
+
+You can find more codes at [HTML Language Code](https://www.w3schools.com/tags/ref_language_codes.asp) and [HTML Country Codes](https://www.w3schools.com/tags/ref_country_codes.asp).
+
+Browsers usually set the language based on their setting or the settings of the operating system.
+
+**Example of HTTP request:**
+
+`http -a zowe:zowe --verify=False GET "https://localhost:10080/api/v1/greeting?name=Petře" Accept-Language:cs-CZ`
+
+```http
+HTTP/1.1 200
+
+{
+    "content": "Ahoj, Petře!",
+    "id": 2,
+    "languageTag": "cs-CZ"
+}
+```
+
+You can also use the query parameter `lang`. For example: `https://localhost:10080/api/v1/greeting?name=Petře&lang=cs`.
+
+The default behavior of the SDK and Spring is to use a cookie in this case to preserve the locale in the browser.
+
+```http
+HTTP/1.1 200
+Set-Cookie: org.springframework.web.servlet.i18n.CookieLocaleResolver.LOCALE=cs; Path=/
+
+{
+    "content": "Ahoj, Petře!",
+    "id": 3,
+    "languageTag": "cs"
+}
+```
 
 ## Setting the Default Server Locale
 
-TODO
+The default locale is `en-US` which stands for US English.
+The Java allows to change it using Java System properties:
+`-Duser.language=en -Duser.country=US`.
+
+The template JCL has these options in there:
+
+```sh
+IJO="$IJO -Duser.language=en -Duser.country=US"
+```

--- a/zowe-rest-api-sample-spring/docs/i18n.md
+++ b/zowe-rest-api-sample-spring/docs/i18n.md
@@ -1,0 +1,118 @@
+# How to Internationalize and Localize Your REST API
+
+What is internationalization (i18n) and localization (l10n)?
+I18n is the process of making the text in your application capable of delivering in multiple languages.
+l10n means that your application has been coded in a way that it meets the language or cultural requirements of a particular locale such as time and date formats, timezones, symbols, currency, or icons.
+
+So, why are they important? Because you want your API service to be as accessible as possible so you can reach maximum users.
+Java apps are relatively straightforward to internationalize, thanks to built-in mechanisms. Same goes for Spring Boot applications and REST API services.
+
+Not every part of the application needs to be localized but it makes sense to have ready for it and externalize the text to be outside of the code.
+The externalization is a good practice anyway and it makes it simpler for review by non-programmers.
+
+There are several approaches to the internationalization:
+
+1. Internationalization at the UI layer only:
+    - This is typical option when only the users of the UI require localization and the users of the REST API are developers who are fine with the US English localization.
+    - The REST API is not localized but it provide output in form of keys or identifiers that are using by the UI and localized there. For example, the REST API response contains: `"error.message.key"` instead `"Localized error message text"`. The UI has defined localizations that contain localized text for `"error.message.key"`.
+    - This is the most easy option for the REST API since there is internalization on its side expect for designing the API to return keys instead of text.
+
+2. Internationalization of the REST API responses:
+    - The responses of the REST API contains localized text based on the locale that the client has requested (usually using the `Accept-Language` HTTP header).
+    - The REST API needs to have the texts externalized and load the correct locale based on the client request. Usually, there is a fallback to a default locale (usually `en-US`).
+
+3. Internationalization of the REST server log messages:
+    - The system programmer can choose what is the localization of the server log messages.
+    - This is not typical. But it makes sense for the numbered and documented messages when the system programmers require other language than US English.
+    - Full localization of all server log messages in more fine grained level is not usually possible because such messages may originate in third-party libraries that do support internationalization.
+
+4. Internationalization of API documentation in Swagger JSON format:
+    - This is not typical for many REST APIs but it can make sense for business application APIs.
+    - Externalizing API documentation string from the Java code to a property file is a good practice.
+
+You should decide what kind of internationalization you need based on the needs of your users. Even if you do not provide localizations, it makes sense to externalize the strings that are displayed to the users.
+
+## Designing API Responses for Localization in UI
+
+An example of a response data that support localization is the standardized message format that is described at [Error Handling](error-handling.md).
+The `messageContent` contains US English text for the API client that do not support i18n. The client that support it will use the `messageKey`
+to lookup the localized message text and will use the `messageParameters` and message formating in the UI to get the final message text.
+
+```json
+{
+    "messages": [
+        {
+            "messageType": "INFO",
+            "messageKey": "sample.message.key",
+            "messageContent": "Text in US English. First parameter is ABC, second is 123.",
+            "messageParameters": [
+                "ABC", 123
+            ]
+        }
+    ]
+}
+```
+
+You can use similar approach to support i18n in your responses.
+
+## Internationalization of the REST API Responses
+
+The sample and the SDK uses standard Java and Spring i18n support: `Locale`, `ResourceBundle`, and `MessageSource`. These classes are explained well in [i18n in Java 11, Spring Boot, and JavaScript](https://developer.okta.com/blog/2019/02/25/java-i18n-internationalization-localization).
+
+The SDK provide does the necessary setup so you just need to define the message text in `messages*.properties` files and load them using `MessageSource`.
+
+To define and use a new externalized string you need to:
+
+1. Define in `messages.properties` in the directory `src/main/resources/messages.properties` in US English:
+
+    ```properties
+    GreetingController.greeting=Hello
+    ```
+
+    **Note:** It is a just common practice to use the class name (for example: `GreetingController`) that is using the message to prevent conflicts. You may have a better conventions for your application.
+
+2. Provide localized values in all locales that you want to support - e.g. to `messages_es.yml` in Spanish:
+
+    ```properties
+    GreetingController.greeting=Hola
+    ```
+
+3. Make your bean to be able to use localized messages by implementing `MessageSourceAware` interface:
+
+    ```java
+    @Bean
+    public class MyClass implements MessageSourceAware {
+        private MessageSource messageSource;
+
+        public void setMessageSource(MessageSource messageSource) {
+            this.messageSource = messageSource;
+        }
+
+        ...
+    ```
+
+4. Get the locale:
+
+   a) From the REST request by calling `LocaleContextHolder.getLocale()`
+   b) From the REST request by defining `@ApiIgnore Locale locale` as an argument of the controller method
+   c) Use the default server locale by calling `Locale.getDefault()` which is by default `en-US`
+
+5. Use it:
+
+    ```java
+    messageSource.getMessage("GreetingController.greeting", null, locale);
+    ```
+
+See [MessageSource](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/MessageSource.html) documentation and [Internationalization using MessageSource](https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#context-functionality-messagesource) for more details.
+
+## Localizing the Standardized Error Messages
+
+TODO
+
+## Requesting a Specific Locale from API Client
+
+TODO
+
+## Setting the Default Server Locale
+
+TODO

--- a/zowe-rest-api-sample-spring/docs/i18n.md
+++ b/zowe-rest-api-sample-spring/docs/i18n.md
@@ -120,13 +120,25 @@ The `ApplicationConfig` class initializes the `errorService` bean.
 
 The `ErrorServiceImpl.getDefault()` creates an error service that load the SDK commons messages and your service messages from YAML files and their localizations from properties files. For your service `messages.yml` and `messages*.properties` are used.
 
-If you want to localize a text of a message defined in `messages.yml` you have to add the localized texts to the `messages*.properties`:
+If you want to localize a text of a message defined in `messages.yml` you have to add the localized texts to the `messages*.properties`.
 
-```properties
-org.zowe.sample.apiservice.greeting.empty.text=Zadané jméno je prázdné. Zadejte jméno, které není prázdné.
+For example, if you have a message defined in `messages.yaml` like:
+
+```yaml
+messages:
+    - key: org.zowe.sample.apiservice.greeting.empty
+      number: ZWEASA001
+      type: ERROR
+      text: "The provided name is empty. Provide a name that is not empty."
 ```
 
-Use the `{messageKey}.text` to define the message text for `{messageKey}`. You can use also the `.reason` and `.action` suffixes.
+You define the Czech localization in `messages_cs.properties`:
+
+```properties
+messages.org.zowe.sample.apiservice.greeting.empty.text=Zadané jméno je prázdné. Zadejte jméno, které není prázdné.
+```
+
+Use the `messages.{messageKey}.text` to define the message text for `{messageKey}`. You can use also the `.reason` and `.action` suffixes.
 
 ## Requesting a Specific Locale from API Client
 

--- a/zowe-rest-api-sample-spring/docs/i18n.md
+++ b/zowe-rest-api-sample-spring/docs/i18n.md
@@ -197,3 +197,17 @@ The template JCL has these options in there:
 ```sh
 IJO="$IJO -Duser.language=en -Duser.country=US"
 ```
+
+### Example for Czech
+
+This needs to be changed in the JCL thats start the service to get proper output in STDOUT:
+
+```sh
+IJO="$IJO -Duser.language=cs -Duser.country=CZ"
+
+export JZOS_OUTPUT_ENCODING="IBM-870"
+```
+
+`JZOS_OUTPUT_ENCODING` causes JZOS batch launcher to convert the Unicode output from Java to IBM-870 when it is being written to a single-byte encoding in STDOUT DD. [IBM-870](https://en.wikipedia.org/wiki/EBCDIC_870) is the EBCDIC Latin-2 charset used in Czechia and other countries in Central Europe.
+
+Your terminal emulator needs to be set up to display IBM-870 correctly.

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/ApplicationConfig.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/ApplicationConfig.java
@@ -30,7 +30,7 @@ public class ApplicationConfig implements ApplicationListener<ApplicationReadyEv
     @Autowired
     private ServiceStartupEventHandler serviceStartupEventHandler;
 
-    private final ErrorService errorService = new ErrorServiceImpl("/messages.yml");
+    private final ErrorService errorService = ErrorServiceImpl.getDefault();
 
     @Bean
     public ErrorService errorService() {

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/Greeting.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/Greeting.java
@@ -19,4 +19,7 @@ public class Greeting {
 
     @ApiModelProperty(value = "The greeting message")
     private final String content;
+
+    @ApiModelProperty(value = "The locale language tag used for this message")
+    private final String languageTag;
 }

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingController.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingController.java
@@ -67,7 +67,8 @@ public class GreetingController implements MessageSourceAware {
             greeting = messageSource.getMessage("GreetingController.greeting", null, locale);
         }
         return new Greeting(counter.incrementAndGet(), String
-                .format(messageSource.getMessage("GreetingController.greetingTemplate", null, locale), greeting, name));
+                .format(messageSource.getMessage("GreetingController.greetingTemplate", null, locale), greeting, name),
+                locale.toLanguageTag());
     }
 
     @PutMapping("settings")

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingControllerExceptionHandler.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingControllerExceptionHandler.java
@@ -10,6 +10,7 @@
 package org.zowe.sample.apiservice.greeting;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -35,7 +36,7 @@ public class GreetingControllerExceptionHandler {
 
     @ExceptionHandler(EmptyNameError.class)
     public ResponseEntity<ApiMessage> handleEmptyName(EmptyNameError exception) {
-        ApiMessage message = errorService.createApiMessage("org.zowe.sample.apiservice.greeting.empty");
+        ApiMessage message = errorService.createApiMessage(LocaleContextHolder.getLocale(), "org.zowe.sample.apiservice.greeting.empty");
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON_UTF8).body(message);
     }

--- a/zowe-rest-api-sample-spring/src/main/jcl/template.jcl
+++ b/zowe-rest-api-sample-spring/src/main/jcl/template.jcl
@@ -55,6 +55,7 @@ LIBPATH="$LIBPATH":"${PWD}/lib"
 export LIBPATH=$LIBPATH
 
 IJO="-Xms16m -Xmx128m"
+IJO="$IJO -Duser.language=en -Duser.country=US"
 IJO="$IJO -Dibm.serversocket.recover=true"
 IJO="$IJO -Dfile.encoding=UTF-8"
 IJO="$IJO -Djava.io.tmpdir=/tmp"

--- a/zowe-rest-api-sample-spring/src/main/jcl/template.jcl
+++ b/zowe-rest-api-sample-spring/src/main/jcl/template.jcl
@@ -68,6 +68,7 @@ IJO="$IJO -Xrunjdwp:transport=dt_socket,$_DEBUG_OPTIONS"
 IJO="$IJO -Xquickstart"
 
 export IBM_JAVA_OPTIONS="${IJO}"
+#export JZOS_OUTPUT_ENCODING="IBM-870"
 export PATH=$JAVA_HOME/bin:$PATH
 
 # Timezone

--- a/zowe-rest-api-sample-spring/src/main/resources/logback-spring.xml
+++ b/zowe-rest-api-sample-spring/src/main/resources/logback-spring.xml
@@ -9,7 +9,7 @@
 
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
+        <encoder class="org.zowe.commons.AccentStrippingPatternLayerEncoder">
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %clr(&lt;ZWEASA1:%thread:${PID:- }&gt;){magenta} %X{userid:-} %clr(\(%logger:%line\)){cyan} %clr(%level) %msg%n</pattern>
         </encoder>
     </appender>

--- a/zowe-rest-api-sample-spring/src/main/resources/messages.properties
+++ b/zowe-rest-api-sample-spring/src/main/resources/messages.properties
@@ -1,0 +1,13 @@
+#
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+#
+
+GreetingController.greeting=Hello
+GreetingController.greetingTemplate=%s, %s\!
+GreetingController.world=world

--- a/zowe-rest-api-sample-spring/src/main/resources/messages.yml
+++ b/zowe-rest-api-sample-spring/src/main/resources/messages.yml
@@ -3,3 +3,7 @@ messages:
       number: ZWEASA001
       type: ERROR
       text: "The provided name is empty. Provide a name that is not empty."
+    - key: org.zowe.commons.service.started
+      number: ZWEASA101
+      type: INFO
+      text: "'%s' has been started in %.3f seconds"

--- a/zowe-rest-api-sample-spring/src/main/resources/messages_cs.properties
+++ b/zowe-rest-api-sample-spring/src/main/resources/messages_cs.properties
@@ -12,3 +12,4 @@ GreetingController.greeting=Ahoj
 GreetingController.greetingTemplate=%s, %s\!
 GreetingController.world=světe
 org.zowe.sample.apiservice.greeting.empty.text=Zadané jméno je prázdné. Zadejte jméno, které není prázdné.
+org.zowe.commons.service.started.text='%s' se spustila za %.3f vteřin

--- a/zowe-rest-api-sample-spring/src/main/resources/messages_cs.properties
+++ b/zowe-rest-api-sample-spring/src/main/resources/messages_cs.properties
@@ -11,5 +11,5 @@
 GreetingController.greeting=Ahoj
 GreetingController.greetingTemplate=%s, %s\!
 GreetingController.world=světe
-org.zowe.sample.apiservice.greeting.empty.text=Zadané jméno je prázdné. Zadejte jméno, které není prázdné.
-org.zowe.commons.service.started.text='%s' se spustila za %.3f vteřin
+messages.org.zowe.sample.apiservice.greeting.empty.text=Zadané jméno je prázdné. Zadejte jméno, které není prázdné.
+messages.org.zowe.commons.service.started.text='%s' se spustila za %.3f vteřin

--- a/zowe-rest-api-sample-spring/src/main/resources/messages_cs.properties
+++ b/zowe-rest-api-sample-spring/src/main/resources/messages_cs.properties
@@ -1,0 +1,13 @@
+#
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+#
+
+GreetingController.greeting=Ahoj
+GreetingController.greetingTemplate=%s, %s\!
+GreetingController.world=světe

--- a/zowe-rest-api-sample-spring/src/main/resources/messages_es.properties
+++ b/zowe-rest-api-sample-spring/src/main/resources/messages_es.properties
@@ -1,0 +1,13 @@
+#
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+#
+
+GreetingController.greeting=Hola
+GreetingController.greetingTemplate=¡%s, %s\!
+GreetingController.world=mundo

--- a/zowe-rest-api-sample-spring/zowe-api.json
+++ b/zowe-rest-api-sample-spring/zowe-api.json
@@ -16,7 +16,7 @@
             }
         }
     },
-    "shellStartCommand": "$JAVA -Djava.library.path=\"./lib:${LIBPATH}\" -Xquickstart -jar bin/zowe-rest-api-sample-spring.jar --spring.config.additional-location=file:etc/application.yml",
+    "shellStartCommand": "$JAVA -Dorg.zowe.commons.logging.stripAccents=true -Duser.language=en -Duser.country=US -Djava.library.path=\"./lib:${LIBPATH}\" -Xquickstart -jar bin/zowe-rest-api-sample-spring.jar --spring.config.additional-location=file:etc/application.yml",
     "jobTemplatePath": "src/main/jcl/template.jcl",
     "jobPath": "build/api.jcl",
     "defaultDirName": "zowe-rest-api-sample-spring",


### PR DESCRIPTION
This a first pull request for #39.

The documentation and instructions are in https://github.com/zowe/sample-spring-boot-api-service/pull/68/files?short_path=d9af631#diff-d9af6310659c7ac8fee1baf3ab693bd1.

The Swagger/Springfox localization is not in this PR and it will be delivered in another PR. This one is over 700 lines now which a high number already.

The Czech localization is not complete and it is not the goal - the purpose is only for testing, not to provide a complete localization.

I realized that some things in the original error messages functionality from the old SDK could be done nicer (e.g. use ResourceBundles, or same formatting using curly braces `{}` as the Spring instead of C-style) but I tried to preserve the existing API and messages.yml format and just add new functionality on top of it so existing users are not affected. 

- [x] A way how to define i18n for strings in the code
- [x] A way how to define i18n for numbered messages (`ErrorService`)
- [x] A method of how the required locale is provided to the REST API is defined and propagated the code that is getting the strings or messages, ideally with a little coding
- [x] A method how the service default locale is defined/configured and used in the threads that are not connected to a REST API request
- [x] Greeting endpoint is localized
- [x] Server messages are localized
- [x] Czech or other localization is provided (for testing purposes)
- [x] Documentation
- [x] Check the special characters in the spool output
- [x] Check the special characters in the SSH session

Suggestions:
- A tool that generates localized ResourceBundle properties with content ready for translation (`.properties` files) with unlocalized and commented text that can be easily translated without going back and forth to the original one and verifies that the translation is complete - added as https://github.com/zowe/sample-spring-boot-api-service/issues/70