### PR TITLE
Check for empty password before calling PlatformUser

### DIFF
--- a/jarpatcher/src/main/java/jarpatcher/JarPatcher.java
+++ b/jarpatcher/src/main/java/jarpatcher/JarPatcher.java
@@ -224,6 +224,7 @@ public class JarPatcher {
         FileOutputStream fos = new FileOutputStream(targetPath.toString());
         ZipOutputStream zipOut = new ZipOutputStream(fos);
         Set<String> deletedOrPatchedNames = new HashSet<>();
+        int keeping = 0;
 
         ZipFile zipPatch = new ZipFile(patchPath);
         Enumeration<? extends ZipEntry> entries = zipPatch.entries();
@@ -252,12 +253,14 @@ public class JarPatcher {
             String filename = entry.getName();
 
             if (!deletedOrPatchedNames.contains(filename)) {
-                logger.info("Keeping: " + filename);
+                keeping++;
                 deletedOrPatchedNames.add(filename);
                 writeEntry(zipOut, deletedOrPatchedNames, zipIn, entry, filename);
             }
         }
         zipIn.close();
+
+        logger.info(String.format("Keeping %d ZIP entries", keeping));
 
         zipOut.close();
         fos.close();

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformErrno2.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformErrno2.java
@@ -1785,6 +1785,8 @@ public enum PlatformErrno2 {
 
     private static Map<Integer, PlatformErrno2> BY_ERRNO = new HashMap<>();
 
+    public static int ERRNO2_BASE = 0x090c0000;
+
     static {
         for (PlatformErrno2 e : values()) {
             BY_ERRNO.put(e.errno2, e);

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformUser.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformUser.java
@@ -20,6 +20,9 @@ public class SafPlatformUser implements PlatformUser {
 
     @Override
     public PlatformReturned authenticate(String userid, String password) {
+        if ((password == null) || password.isEmpty()) {
+            return PlatformReturned.builder().success(false).rc(0).errno(PlatformPwdErrno.EINVAL.errno).errno2(PlatformErrno2.ERRNO2_BASE | PlatformErrno2.JRPasswordLenError.errno2).build();
+        }
         try {
             Object safReturned = platformClassFactory.getPlatformUserClass()
                     .getMethod("authenticate", String.class, String.class)

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformUserTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformUserTests.java
@@ -10,6 +10,7 @@
  */
 package org.zowe.commons.zos.security.platform;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.zowe.commons.zos.security.platform.MockPlatformUser.VALID_PASSWORD;
@@ -28,9 +29,18 @@ public class SafPlatformUserTests {
     }
 
     @Test
-    public void returnsDetailsForInvalidAuthentication() {
+    public void returnsErrorDetailsForInvalidAuthentication() {
         PlatformReturned returned = safPlatformUser.authenticate(INVALID_USERID, INVALID_PASSWORD);
         assertFalse(returned.isSuccess());
     }
 
+    @Test
+    public void returnsErrorDetailsForEmptyPassword() {
+        PlatformReturned returned = safPlatformUser.authenticate(VALID_USERID, "");
+        assertFalse(returned.isSuccess());
+        assertEquals(PlatformPwdErrno.EINVAL.errno, returned.errno);
+        assertEquals(0, returned.rc);
+        assertEquals(0x090C02A7, returned.errno2);
+        assertEquals(PlatformErrno2.JRPasswordLenError, PlatformErrno2.valueOfErrno(returned.errno2));
+    }
 }

--- a/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/security/SecurityContextControllerIntegrationTests.java
+++ b/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/security/SecurityContextControllerIntegrationTests.java
@@ -49,6 +49,12 @@ public class SecurityContextControllerIntegrationTests extends IntegrationTests 
     }
 
     @Test
+    public void failsWithEmptyPassword() throws Exception {
+        RestAssured.authentication = basic(VALID_USERID, "");
+        when().get("/api/v1/securityTest/authenticatedUser").then().statusCode(401);
+    }
+
+    @Test
     public void failsWithExpiredAuthentication() throws Exception {
         assumeTrue("The service under test is not running on localhost",
                 LOCAL_PROFILE.equalsIgnoreCase(serviceUnderTest.getProfile()));


### PR DESCRIPTION
Checks for an empty password before calling [`PlatformUser.authenticate()`](https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.zsecurity.api.80.doc/com.ibm.os390.security/com/ibm/os390/security/PlatformUser.html#authenticate-java.lang.String-java.lang.String-) method from IBM JDK that could succeed in this situation. This has been a valid behavior of the underlying BPX4PWD callable service:

> The name of a fullword that contains the length of the Pass parameter. This length must be between 1 and 8 characters for a password or PassTicket or between 9 and 100 characters for a password phrase. A length of zero indicates that the Pass parameter is to be ignored and causes a `SURROGAT` class check.

So it could succeed with an empty password in cases when the server user ID passed the `SURROGAT` class check.

Since it is a highly unexpected behavior that is documented three levels below the `org.zowe.commons.zos.security.platform.PlatformUser.authenticate()` documentation, the `org.zowe.commons.zos.security.platformPlatformUser.authenticate()` will fail with errno `EINVAL` (121). If the `SURROGAT` class check is needed in future then it will be implemented a special method to prevent this confusion.

Resolves #72 