### PR TITLE
Improved security requirements diagnostics and documentation

### DIFF
--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/jni/Secur.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/jni/Secur.java
@@ -26,4 +26,6 @@ public class Secur {
     public native int createSecurityEnvironmentByDaemon(String userid, String applId);
 
     public native int removeSecurityEnvironment();
+
+    public native int getLastErrno2();
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformErrno2.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformErrno2.java
@@ -1806,4 +1806,8 @@ public enum PlatformErrno2 {
     public static PlatformErrno2 valueOfErrno(int errno2) {
         return BY_ERRNO.get(errno2 & 0xffff);
     }
+
+	public String format() {
+		return String.format("%s %s", this.name, this.explanation);
+	}
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/AccessControlService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/AccessControlService.java
@@ -92,7 +92,7 @@ public abstract class AccessControlService implements PlatformSecurityService {
             if (!result) {
                 String message = String.format("%s access to resource %s in %s class is required for the %s action",
                         accessLevel.toString(), resourceName, resourceClass, action);
-                log.error(message);
+                log.warn(message);
             } else {
                 validatedServerSecurity.add(resourceString);
             }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/AccessControlService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/AccessControlService.java
@@ -9,9 +9,6 @@
  */
 package org.zowe.commons.zos.security.service;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.zowe.commons.zos.security.platform.PlatformAccessControl;
 import org.zowe.commons.zos.security.platform.PlatformAccessControl.AccessLevel;
 import org.zowe.commons.zos.security.platform.PlatformAckErrno;
@@ -22,8 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class AccessControlService implements PlatformSecurityService {
-    private Set<String> validatedServerSecurity = new HashSet<>();
-
     protected PlatformAccessControl platformAccessControl = null;
 
     protected PlatformAccessControl getPlatformAccessControl() {
@@ -33,7 +28,6 @@ public abstract class AccessControlService implements PlatformSecurityService {
     @Override
     public boolean checkPermission(String userid, String resourceClass, String resourceName, AccessLevel accessLevel,
             boolean resourceHasToExist) {
-        validateServerSecurity("check permission", "FACILITY", "BPX.SERVER", AccessLevel.READ);
         PlatformReturned returned = getPlatformAccessControl().checkPermission(userid, resourceClass, resourceName,
                 accessLevel.getValue());
         return evaluatePlatformReturned(returned, resourceHasToExist);
@@ -81,21 +75,5 @@ public abstract class AccessControlService implements PlatformSecurityService {
     @Override
     public boolean checkPermission(String resourceClass, String resourceName, AccessLevel accessLevel) {
         return checkPermission(resourceClass, resourceName, accessLevel, true);
-    }
-
-    protected void validateServerSecurity(String action, String resourceClass, String resourceName,
-            AccessLevel accessLevel) {
-
-        String resourceString = String.format("%s.%s.%s", resourceClass, resourceName, accessLevel.toString());
-        if (!validatedServerSecurity.contains(resourceString)) {
-            boolean result = checkPermission(resourceClass, resourceName, accessLevel);
-            if (!result) {
-                String message = String.format("%s access to resource %s in %s class is required for the %s action",
-                        accessLevel.toString(), resourceName, resourceClass, action);
-                log.warn(message);
-            } else {
-                validatedServerSecurity.add(resourceString);
-            }
-        }
     }
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/AccessControlService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/AccessControlService.java
@@ -9,16 +9,21 @@
  */
 package org.zowe.commons.zos.security.service;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.zowe.commons.zos.security.platform.PlatformAccessControl;
+import org.zowe.commons.zos.security.platform.PlatformAccessControl.AccessLevel;
 import org.zowe.commons.zos.security.platform.PlatformAckErrno;
 import org.zowe.commons.zos.security.platform.PlatformErrno2;
 import org.zowe.commons.zos.security.platform.PlatformReturned;
-import org.zowe.commons.zos.security.platform.PlatformAccessControl.AccessLevel;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class AccessControlService implements PlatformSecurityService {
+    private Set<String> validatedServerSecurity = new HashSet<>();
+
     protected PlatformAccessControl platformAccessControl = null;
 
     protected PlatformAccessControl getPlatformAccessControl() {
@@ -28,6 +33,7 @@ public abstract class AccessControlService implements PlatformSecurityService {
     @Override
     public boolean checkPermission(String userid, String resourceClass, String resourceName, AccessLevel accessLevel,
             boolean resourceHasToExist) {
+        validateServerSecurity("check permission", "FACILITY", "BPX.SERVER", AccessLevel.READ);
         PlatformReturned returned = getPlatformAccessControl().checkPermission(userid, resourceClass, resourceName,
                 accessLevel.getValue());
         return evaluatePlatformReturned(returned, resourceHasToExist);
@@ -75,5 +81,21 @@ public abstract class AccessControlService implements PlatformSecurityService {
     @Override
     public boolean checkPermission(String resourceClass, String resourceName, AccessLevel accessLevel) {
         return checkPermission(resourceClass, resourceName, accessLevel, true);
+    }
+
+    protected void validateServerSecurity(String action, String resourceClass, String resourceName,
+            AccessLevel accessLevel) {
+
+        String resourceString = String.format("%s.%s.%s", resourceClass, resourceName, accessLevel.toString());
+        if (!validatedServerSecurity.contains(resourceString)) {
+            boolean result = checkPermission(resourceClass, resourceName, accessLevel);
+            if (!result) {
+                String message = String.format("%s access to resource %s in %s class is required for the %s action",
+                        accessLevel.toString(), resourceName, resourceClass, action);
+                log.error(message);
+            } else {
+                validatedServerSecurity.add(resourceString);
+            }
+        }
     }
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/ZosJniPlatformSecurityService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/ZosJniPlatformSecurityService.java
@@ -60,8 +60,8 @@ public class ZosJniPlatformSecurityService extends AccessControlService
                 explanation += ". " + platformErrno2.format();
             }
             log.error("Platform security action to {} has failed: {}; errno={}; errno2={}", action, explanation, errno,
-                    errno2, String.format("%08x", errno2));
-            if (errno2 == PlatformErrno2.JRNoChangeIdentity.errno2) {
+                    String.format("%08x", errno2));
+            if (PlatformErrno2.JRNoChangeIdentity.equals(platformErrno2)) {
                 log.error(
                         "The server user ID does not have authority to change the thread-level security. UPDATE access to BPX.SERVER in the facility resource class is required, or READ access if the user ID is superuser");
             }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/ZosJniPlatformSecurityService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/ZosJniPlatformSecurityService.java
@@ -68,7 +68,7 @@ public class ZosJniPlatformSecurityService extends AccessControlService
     @Override
     public void createThreadSecurityContextByDaemon(String userId, String applId) {
         String action = "create thread-level security environment without password";
-        validateServerSecurity(action, "FACILITY", "BPX.DAEMON", AccessLevel.READ);
+        validateServerSecurity(action, "FACILITY", "BPX.DAEMON", AccessLevel.UPDATE);
         checkErrno(action, secur.createSecurityEnvironmentByDaemon(userId, applId), CREATE_THREAD_SECURITY_CONTEXT);
     }
 

--- a/zowe-rest-api-commons-spring/src/test/resources/test-saf.yml
+++ b/zowe-rest-api-commons-spring/src/test/resources/test-saf.yml
@@ -12,6 +12,9 @@ safAccess:
     BPX.SERVER: # resource
       READ: # access level
         - ZOWE # users
+    BPX.DAEMON:
+      UPDATE:
+        - ZOWE
   ZOWE:
     SAMPLE.RESOURCE:
       UPDATE:

--- a/zowe-rest-api-commons-spring/src/test/resources/test-saf.yml
+++ b/zowe-rest-api-commons-spring/src/test/resources/test-saf.yml
@@ -8,6 +8,10 @@
 # This file is stored in `src/test/resources/test-saf.yml` which means that it will be used by the unit tests only.
 #
 safAccess:
+  FACILITY: # class
+    BPX.SERVER: # resource
+      READ: # access level
+        - ZOWE # users
   ZOWE:
     SAMPLE.RESOURCE:
       UPDATE:

--- a/zowe-rest-api-commons-spring/zossrc/secur.c
+++ b/zowe-rest-api-commons-spring/zossrc/secur.c
@@ -11,6 +11,8 @@
 https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.bpxbd00/ptsec.htm
 */
 
+int lastErrno2 = 0;
+
 JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_createSecurityEnvironmentByDaemon(JNIEnv *env, jobject obj, jstring user, jstring applId)
 {
     int rc = EINVAL;
@@ -21,9 +23,11 @@ JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_createSecuri
         int userLength = strlen(platformUser);
         if (pthread_security_applid_np(__DAEMON_SECURITY_ENV, __USERID_IDENTITY, userLength, platformUser, NULL, 0, platformApplId) != 0) {
             rc = errno;
+            lastErrno2 = __errno2();
         }
         else {
             rc = 0;
+            lastErrno2 = 0;
         }
     }
     free_if_not_null(platformUser);
@@ -42,9 +46,11 @@ JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_createSecuri
         int userLength = strlen(platformUser);
         if (pthread_security_applid_np(__CREATE_SECURITY_ENV, __USERID_IDENTITY, userLength, platformUser, platformPassword, 0, platformApplId) != 0) {
             rc = errno;
+            lastErrno2 = __errno2();
         }
         else {
             rc = 0;
+            lastErrno2 = 0;
         }
     }
     free_if_not_null(platformUser);
@@ -55,4 +61,9 @@ JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_createSecuri
 JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_removeSecurityEnvironment(JNIEnv *env, jobject obj)
 {
     return pthread_security_applid_np(__DELETE_SECURITY_ENV, __USERID_IDENTITY, 0, NULL, NULL, 0, NULL);
+}
+
+JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_getLastErrno2(JNIEnv *env, jobject obj)
+{
+    return lastErrno2;
 }

--- a/zowe-rest-api-commons-spring/zossrc/secur.h
+++ b/zowe-rest-api-commons-spring/zossrc/secur.h
@@ -31,6 +31,14 @@ JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_createSecuri
 JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_removeSecurityEnvironment
   (JNIEnv *, jobject);
 
+/*
+ * Class:     org_zowe_commons_zos_security_jni_Secur
+ * Method:    getLastErrno2
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_getLastErrno2
+  (JNIEnv *env, jobject obj);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zowe-rest-api-sample-spring/docs/zos-security.md
+++ b/zowe-rest-api-sample-spring/docs/zos-security.md
@@ -221,7 +221,7 @@ We recommend to use #1 since it has no dependencies (but #2 has) and the shared 
 
 In case of #1 and #2 there are two methods with different security requirements:
 
-- a) The service user ID has READ access to the  `BPX.DAEMON` resource in the FACILITY class
+- a) The service user ID has UPDATE access to the `BPX.DAEMON` resource in the FACILITY class (or READ access and is superuser)
   - This allows to use `pthread_security_applid_np` without password and with `TLS_DAEMON_THREAD_SEC#` function
   - The service needs to validate the authentication (e.g. Zowe JWT token) so there is no need to obtain the PassTicket or remember the password
 
@@ -362,7 +362,7 @@ TSS PERMIT(userid) UNIXPRIV(SUPERUSER.FILESYS.MOUNT) ACCESS(UPDATE)
 TSS PERMIT(userid) IBMFAC(BPX.FILEATTR.PROGCTL) ACCESS(READ)
 TSS PERMIT(userid) IBMFAC(BPX.FILEATTR.APF) ACCESS(READ)
 TSS PERMIT(userid) IBMFAC(BPX.SERVER) ACCESS(READ)
-TSS PERMIT(userid) IBMFAC(BPX.DAEMON) ACCESS(READ)
+TSS PERMIT(userid) IBMFAC(BPX.DAEMON) ACCESS(UPDATE)
 ```
 
 Commands for RACF:
@@ -372,7 +372,7 @@ PERMIT SUPERUSER.FILESYS.MOUNT CLASS(UNIXPRIV) ID(userid) ACCESS(UPDATE)
 PERMIT BPX.FILEATTR.PROGCTL CLASS(FACILITY) ID(userid) ACCESS(READ)
 PERMIT BPX.FILEATTR.APF CLASS(FACILITY) ID(userid) ACCESS(READ)
 PERMIT BPX.SERVER CLASS(FACILITY) ID(userid) ACCESS(READ)
-PERMIT BPX.DAEMON CLASS(FACILITY) ID(userid) ACCESS(READ)
+PERMIT BPX.DAEMON CLASS(FACILITY) ID(userid) ACCESS(UPDATE)
 SETROPTS RACLIST(FACILITY) REFRESH
 SETROPTS RACLIST(UNIXPRIV) REFRESH
 ```

--- a/zowe-rest-api-sample-spring/docs/zos-security.md
+++ b/zowe-rest-api-sample-spring/docs/zos-security.md
@@ -221,15 +221,21 @@ We recommend to use #1 since it has no dependencies (but #2 has) and the shared 
 
 In case of #1 and #2 there are two methods with different security requirements:
 
-- a) The service user ID has UPDATE access to the BPX.DAEMON resource in the FACILITY class
-  - This allows to use `pthread_security_applid_np` without password
-  - The service needs to validate the authentication (e.g. Zowe JWT token) so there is not need to obtain the PassTicket or remember the password
+- a) The service user ID has READ access to the  `BPX.DAEMON` resource in the FACILITY class
+  - This allows to use `pthread_security_applid_np` without password and with `TLS_DAEMON_THREAD_SEC#` function
+  - The service needs to validate the authentication (e.g. Zowe JWT token) so there is no need to obtain the PassTicket or remember the password
 
-- b) The service user ID has READ access to the BPX.SERVER resource in the FACILITY class
+- b) The service user ID has READ access to the `BPX.SERVER` resource in the FACILITY class
   - The `pthread_security_applid_np` needs to be called with a password or a valid PassTicket
   - This requires a REST API that generates a PassTicket if you have a valid JWT token
 
-Currenly **#1 a)** - `pthread_security_applid_np` via JNI without password and `BPX.DAEMON` requirement is implemented.
+- c) The service user ID has UPDATE access to the `BPX.SERVER` resource in the facility class
+  - The server is capable of acting as a surrogate for the client
+  - The server needs to have READ access to `BPX.SRV.<userid>` in the SURROGAT class
+  - The `pthread_security_applid_np` needs to be called with empty password
+  - See <https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.4.0/com.ibm.zos.v2r4.bpxb200/srvdef.htm>
+
+Currenly **#1 a)** - `pthread_security_applid_np` via JNI without password and with `BPX.DAEMON` requirement is implemented.
 
 **#1 b)** is defined in the backlog as <https://github.com/zowe/sample-spring-boot-api-service/issues/17>.
 
@@ -319,8 +325,8 @@ The SDK defined two new security expressions:
     ```yaml
     zowe.commons.security.saf:
         serviceResourceClass: "ZOWE"
-        serviceResourceNamePrefix: "SAMPLE."    
-    ```    
+        serviceResourceNamePrefix: "SAMPLE."
+    ```
 
 So you can do following:
 
@@ -341,8 +347,13 @@ The second `@PreAuthorize` expression `hasSafServiceResourceAccess('RESOURCE', '
 You need following access to be able to develop a REST API service:
 
 - `UPDATE` access to the `SUPERUSER.FILESYS.MOUNT` resource in the UNIXPRIV class
-- `READ` access to `BPX.FILEATTR.PROGCTL` and `BPX.FILEATTR.APF` in the facility class
-- `UPDATE` access to `BPX.SERVER`
+- `READ` access to `BPX.FILEATTR.PROGCTL` and `BPX.FILEATTR.APF` in the FACILITY class
+
+You need following access to be able to run a REST API service:
+
+- `READ` access to `BPX.SERVER` in the FACILITY class to be able to check access to resources
+- `READ` access to `BPX.DAEMON` in the FACILITY class to be able to establish thread-level security
+- nothing special if you want to be able to authenticate users
 
 Commands for CA Top Secret for z/OS:
 
@@ -350,7 +361,8 @@ Commands for CA Top Secret for z/OS:
 TSS PERMIT(userid) UNIXPRIV(SUPERUSER.FILESYS.MOUNT) ACCESS(UPDATE)
 TSS PERMIT(userid) IBMFAC(BPX.FILEATTR.PROGCTL) ACCESS(READ)
 TSS PERMIT(userid) IBMFAC(BPX.FILEATTR.APF) ACCESS(READ)
-TSS PERMIT(userid) IBMFAC(BPX.SERVER) ACCESS(UPDATE)
+TSS PERMIT(userid) IBMFAC(BPX.SERVER) ACCESS(READ)
+TSS PERMIT(userid) IBMFAC(BPX.DAEMON) ACCESS(READ)
 ```
 
 Commands for RACF:
@@ -359,7 +371,8 @@ Commands for RACF:
 PERMIT SUPERUSER.FILESYS.MOUNT CLASS(UNIXPRIV) ID(userid) ACCESS(UPDATE)
 PERMIT BPX.FILEATTR.PROGCTL CLASS(FACILITY) ID(userid) ACCESS(READ)
 PERMIT BPX.FILEATTR.APF CLASS(FACILITY) ID(userid) ACCESS(READ)
-PERMIT BPX.SERVER CLASS(FACILITY) ID(userid) ACCESS(UPDATE)
+PERMIT BPX.SERVER CLASS(FACILITY) ID(userid) ACCESS(READ)
+PERMIT BPX.DAEMON CLASS(FACILITY) ID(userid) ACCESS(READ)
 SETROPTS RACLIST(FACILITY) REFRESH
 SETROPTS RACLIST(UNIXPRIV) REFRESH
 ```

--- a/zowe-rest-api-sample-spring/src/main/jcl/template.jcl
+++ b/zowe-rest-api-sample-spring/src/main/jcl/template.jcl
@@ -86,6 +86,8 @@ export ${TIMEZONE%%#*}
 export JAVA_DUMP_HEAP=false
 export JAVA_PROPAGATE=NO
 export IBM_JAVA_ZOS_TDUMP=NO
+export _EDC_ADD_ERRNO2=1
+export _BPXK_JOBLOG=STDERR
 
 echo "Working directory: `pwd`"
 /*

--- a/zowe-rest-api-sample-spring/src/main/resources/test-saf.yml
+++ b/zowe-rest-api-sample-spring/src/main/resources/test-saf.yml
@@ -14,7 +14,7 @@ safAccess:
       READ: # access level
         - ZOWE # users
     BPX.DAEMON:
-      READ:
+      UPDATE:
         - ZOWE
   UNIXPRIV:
     SUPERUSER.FILESYS.MOUNT:

--- a/zowe-rest-api-sample-spring/src/main/resources/test-saf.yml
+++ b/zowe-rest-api-sample-spring/src/main/resources/test-saf.yml
@@ -11,8 +11,11 @@
 safAccess:
   FACILITY: # class
     BPX.SERVER: # resource
-      UPDATE: # access level
+      READ: # access level
         - ZOWE # users
+    BPX.DAEMON:
+      READ:
+        - ZOWE
   UNIXPRIV:
     SUPERUSER.FILESYS.MOUNT:
       READ:


### PR DESCRIPTION
This PR improves diagnostics information when `createSecurityEnvironmentByDaemon` method fails. The `errno2` is collected from the native code and translated into a readable message. In case of `JRNoChangeIdentity`, a message that that explains security requirements has been added.

Documentation and security command examples were updated to describe the required access to BPX.SERVER and BPX.DEAMON for security functions in the SDK.

The `/resourceAccess` endpoint has been added for testing purposed to check the access.

Testing:
- [x] RACF
- [x] Top Secret

For example, in case a missing authority to change user ID, you will get following message:
```
2019-11-20 02:34:30.105 <ZWEASA1:https-jsse-nio-0.0.0.0-20081-exec-9:33621086> SDKBLD1 (org.zowe.commons.zos.security.service.Z
PlatformSecurityService:62) ERROR Platform security action to create thread-level security environment without password has fai
EPERM The calling address space is not authorized to use this service or a load from a not program-controlled library was done
e address space. JRNoChangeIdentity The invoker is not authorized to change MVS userids; errno=139; errno2=x'0be803d1
2019-11-20 02:34:30.163 <ZWEASA1:https-jsse-nio-0.0.0.0-20081-exec-9:33621086> SDKBLD1 (org.zowe.commons.zos.security.service.Z
PlatformSecurityService:65) ERROR The server user ID does not have authority to change the thread-level security. UPDATE access
PX.SERVER in the facility resource class is required, or READ access if the user ID is superuser
```