### PR TITLE
Store all artifacts created by the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
             cd zowe-api-dev
             npm install
             npm pack
+            mkdir -p ./build/
             cp -v zowedev-zowe-api-dev-*.tgz ../build/zowedev-zowe-api-dev.tgz
       - store_artifacts:
           path: build/zowedev-zowe-api-dev.tgz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             cd zowe-api-dev
             npm install
             npm pack
-            mkdir -p ./build/
+            mkdir -p ../build/
             cp -v zowedev-zowe-api-dev-*.tgz ../build/zowedev-zowe-api-dev.tgz
       - store_artifacts:
           path: build/zowedev-zowe-api-dev.tgz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
             cd zowe-api-dev
             npm install
             npm pack
+      - store_artifacts:
+          path: zowe-api-dev/zowedev-zowe-api-dev-0.0.0-dev.tgz
+          destination: zowedev-zowe-api-dev.tgz
       - run: &zosbuild
           name: Building Native z/OS Code
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,9 @@ jobs:
             cd zowe-api-dev
             npm install
             npm pack
+            cp -v zowedev-zowe-api-dev-*.tgz ../build/zowedev-zowe-api-dev.tgz
       - store_artifacts:
-          path: zowe-api-dev/zowedev-zowe-api-dev-0.0.0-dev.tgz
+          path: build/zowedev-zowe-api-dev.tgz
           destination: zowedev-zowe-api-dev.tgz
       - run: &zosbuild
           name: Building Native z/OS Code
@@ -40,9 +41,8 @@ jobs:
           name: Building Standalone Sample
           command: |
             scripts/build-sample.sh
-            cp ~/code/zowe-rest-api-sample-spring/build/libs/zowe-rest-api-sample-spring-*.jar ~/code/zowe-rest-api-sample-spring/build/libs/zowe-rest-api-sample-spring.jar
       - store_artifacts:
-          path: ~/code/zowe-rest-api-sample-spring/build/libs/zowe-rest-api-sample-spring.jar
+          path: build/zowe-rest-api-sample-spring.jar
           destination: zowe-rest-api-sample-spring.jar
       - run: &integration_tests_sample
           name: Running Integration Tests of the Sample in the Build Container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ jobs:
           name: Building Standalone Sample
           command: |
             scripts/build-sample.sh
+      - store_artifacts: &store_sample_jar
+          path: ~/code/zowe-rest-api-sample-spring/build/libs/zowe-rest-api-sample-spring-*.jar
+          destination: zowe-rest-api-sample-spring.jar
       - run: &integration_tests_sample
           name: Running Integration Tests of the Sample in the Build Container
           command: |
@@ -53,7 +56,7 @@ jobs:
             source .circleci/river.env
             npm run zos-cleanup
             scripts/package-sample.sh
-      - store_artifacts:
+      - store_artifacts: &store_sample_zip
           path: ~/code/build/zowe-rest-api-sample-spring.zip
           destination: zowe-rest-api-sample-spring.zip
       - save_cache:
@@ -78,6 +81,7 @@ jobs:
       - run: *build
       - codecov/upload
       - run: *sample
+      - run: *store_sample_jar
       - run: *integration_tests_sample
       - run: *integration_tests_sample_zos
       - run: *zos_cleanup
@@ -100,6 +104,7 @@ jobs:
           command: |
             scripts/package-sample.sh
             scripts/publish-sample.sh
+      - run: *store_sample_zip
 workflows:
   version: 2
   untagged_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,9 @@ jobs:
           name: Building Standalone Sample
           command: |
             scripts/build-sample.sh
+            cp ~/code/zowe-rest-api-sample-spring/build/libs/zowe-rest-api-sample-spring-*.jar ~/code/zowe-rest-api-sample-spring/build/libs/zowe-rest-api-sample-spring.jar
       - store_artifacts:
-          path: ~/code/zowe-rest-api-sample-spring/build/libs/zowe-rest-api-sample-spring-*.jar
+          path: ~/code/zowe-rest-api-sample-spring/build/libs/zowe-rest-api-sample-spring.jar
           destination: zowe-rest-api-sample-spring.jar
       - run: &integration_tests_sample
           name: Running Integration Tests of the Sample in the Build Container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           name: Building Standalone Sample
           command: |
             scripts/build-sample.sh
-      - store_artifacts: &store_sample_jar
+      - store_artifacts:
           path: ~/code/zowe-rest-api-sample-spring/build/libs/zowe-rest-api-sample-spring-*.jar
           destination: zowe-rest-api-sample-spring.jar
       - run: &integration_tests_sample
@@ -81,7 +81,6 @@ jobs:
       - run: *build
       - codecov/upload
       - run: *sample
-      - run: *store_sample_jar
       - run: *integration_tests_sample
       - run: *integration_tests_sample_zos
       - run: *zos_cleanup
@@ -104,7 +103,6 @@ jobs:
           command: |
             scripts/package-sample.sh
             scripts/publish-sample.sh
-      - run: *store_sample_zip
 workflows:
   version: 2
   untagged_build:

--- a/scripts/build-sample.sh
+++ b/scripts/build-sample.sh
@@ -21,3 +21,5 @@ echo "zoweSampleVersion=$VERSION" >> gradle.properties
 ./gradlew build
 
 rm build.gradle-orig
+
+cp -v build/libs/zowe-rest-api-sample-spring-*.jar ../build/zowe-rest-api-sample-spring.jar

--- a/scripts/publish-sample.sh
+++ b/scripts/publish-sample.sh
@@ -7,3 +7,5 @@ curl -OL https://github.com/aktau/github-release/releases/download/v0.7.2/${PLAT
 tar -xjvf ${PLATFORM_OS}-${PLATFORM_ARCH}-github-release.tar.bz2
 bin/${PLATFORM_OS}/${PLATFORM_ARCH}/github-release info -u zowe -r sample-spring-boot-api-service
 bin/${PLATFORM_OS}/${PLATFORM_ARCH}/github-release upload -u zowe -r sample-spring-boot-api-service -t ${TAG} -n "zowe-rest-api-sample-spring.zip" -f zowe-rest-api-sample-spring.zip
+bin/${PLATFORM_OS}/${PLATFORM_ARCH}/github-release upload -u zowe -r sample-spring-boot-api-service -t ${TAG} -n "zowe-rest-api-sample-spring.jar" -f zowe-rest-api-sample-spring.jar
+bin/${PLATFORM_OS}/${PLATFORM_ARCH}/github-release upload -u zowe -r sample-spring-boot-api-service -t ${TAG} -n "zowedev-zowe-api-dev.tgz" -f zowedev-zowe-api-dev.tgz


### PR DESCRIPTION
This stores also:
- `zowedev-zowe-api-dev.tgz`
- `zowe-rest-api-sample-spring.jar`

They are stored as CircleCI artifacts and attached GitHub releases if applicable.

The reason is to enable scanning of these artifacts by external tools.
