### PR TITLE
PassTicket support

### DIFF
--- a/zowe-rest-api-commons-spring/src/main/java/META-INF/additional-spring-configuration-metadata.json
+++ b/zowe-rest-api-commons-spring/src/main/java/META-INF/additional-spring-configuration-metadata.json
@@ -108,7 +108,7 @@
         {
             "name": "zowe.commons.security.saf",
             "type": "java.util.Map",
-            "description": "Configuration of the resource access checking using SAF'"
+            "description": "Configuration of the authentication and resource access checking using SAF"
         },
         {
             "name": "zowe.commons.security.saf.serviceResourceClass",
@@ -119,6 +119,11 @@
             "name": "zowe.commons.security.saf.serviceResourceNamePrefix",
             "type": "java.lang.String",
             "description": "The prefix of the SAF resource name that is used to check access to resources using `hasSafServiceResourceAccess()` security expression. The suffix is appended directly to the prefix without any separator so you need to include `.` at the end of prefix if you want to the suffix to start after `.`.\n\nFor example: `ZOWE.`"
+        },
+        {
+            "name": "zowe.commons.security.saf.applid",
+            "type": "java.util.Map",
+            "description": "The APPLID using for authentication"
         }
     ]
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/ZosUtils.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/ZosUtils.java
@@ -1,0 +1,24 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.commons.zos;
+
+public class ZosUtils {
+    private ZosUtils() {
+        // no instances
+    }
+
+    /**
+     * @return True when running on z/OS.
+     */
+    public static boolean isRunningOnZos() {
+        String osName = System.getProperty("os.name");
+        return "z/OS".equals(osName);
+    }
+}

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationProvider.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationProvider.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -29,6 +30,7 @@ import org.zowe.commons.zos.security.platform.PlatformReturned;
 import org.zowe.commons.zos.security.platform.PlatformUser;
 import org.zowe.commons.zos.security.platform.SafPlatformClassFactory;
 import org.zowe.commons.zos.security.platform.SafPlatformUser;
+import org.zowe.commons.zos.security.platform.SafUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,10 +44,14 @@ public class ZosAuthenticationProvider implements AuthenticationProvider, Initia
     @Autowired
     private Environment environment;
 
+    @Value("${zowe.commons.security.saf.applid:}")
+    private String applid;
+
     @Override
     public Authentication authenticate(Authentication authentication) {
         String userid = authentication.getName();
         String password = authentication.getCredentials().toString();
+        SafUtils.setThreadApplid(applid);
         PlatformReturned returned = getPlatformUser().authenticate(userid, password);
 
         if ((returned == null) || (returned.isSuccess())) {
@@ -94,6 +100,12 @@ public class ZosAuthenticationProvider implements AuthenticationProvider, Initia
                 platformUser = new MockPlatformUser();
                 log.warn("The mock authentication provider is used. This application should not be used in production");
             }
+        }
+        if ((applid != null) && !applid.isEmpty()) {
+            log.info("APPLID is " + applid);
+        }
+        else {
+            log.info("APPLID is not set. PassTickets are not enabled");
         }
     }
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/jni/Secur.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/jni/Secur.java
@@ -28,4 +28,6 @@ public class Secur {
     public native int removeSecurityEnvironment();
 
     public native int getLastErrno2();
+
+    public native int setApplid(String applid);
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformUser.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformUser.java
@@ -24,5 +24,5 @@ public interface PlatformUser {
      * @return If successful, a null object is returned. If not successful an instance of
      * the PlatformReturned class is returned.
      */
-    PlatformReturned authenticate(java.lang.String userid, java.lang.String password);
+    PlatformReturned authenticate(String userid, String password);
 }

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafUtils.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafUtils.java
@@ -1,0 +1,43 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.commons.zos.security.platform;
+
+import org.zowe.commons.zos.ZosUtils;
+import org.zowe.commons.zos.security.jni.Secur;
+
+public class SafUtils {
+    private SafUtils() {
+        // no instances
+    }
+
+    private static ThreadLocal<String> threadApplid = new ThreadLocal<>();
+
+    /**
+     * Sets the APPLID for the current thread so the PlatformUser.authenticate can
+     * use PassTickets for the provide APPLID.
+     *
+     * The APPLID can be changed but not unset.
+     *
+     * @param applid The APPLID to be set. Up to 8 characters.
+     */
+    public static void setThreadApplid(String applid) {
+        if ((applid == null) || applid.isEmpty()) {
+            return;
+        }
+
+        String currentApplid = threadApplid.get();
+        if (currentApplid == null || !currentApplid.equals(applid)) {
+            if (ZosUtils.isRunningOnZos()) {
+                new Secur().setApplid(applid);
+            }
+            threadApplid.set(applid);
+        }
+    }
+}

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformUserTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformUserTests.java
@@ -30,6 +30,12 @@ public class SafPlatformUserTests {
     }
 
     @Test
+    public void worksWithSetApplid() {
+        SafUtils.setThreadApplid("APPLID");
+        assertNull(safPlatformUser.authenticate(VALID_USERID, VALID_PASSWORD));
+    }
+
+    @Test
     public void returnsErrorDetailsForInvalidAuthentication() {
         PlatformReturned returned = safPlatformUser.authenticate(INVALID_USERID, INVALID_PASSWORD);
         assertFalse(returned.isSuccess());

--- a/zowe-rest-api-commons-spring/zossrc/secur.c
+++ b/zowe-rest-api-commons-spring/zossrc/secur.c
@@ -80,13 +80,9 @@ JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_setApplid(JN
 {
     void *__ptr32 psa = 0;
     void *__ptr32 tcb = *(void *__ptr32 *)(psa + PSATOLD);
-    printf("tcb=%p\n", tcb);
     void *__ptr32 stcb = *(void *__ptr32 *)(tcb + TCBSTCB);
-    printf("stcb=%p\n", stcb);
     void *__ptr32 otcb = *(void *__ptr32 *)(stcb + STCBOTCB);
-    printf("otcb=%p\n", otcb);
     void *__ptr32 thli = *(void *__ptr32 *)(otcb + OTCBTHLI);
-    printf("thli=%p\n", thli);
 
     if (memcmp("THLI", thli, 4) != 0)
     {
@@ -99,9 +95,6 @@ JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_setApplid(JN
     char *applid = jstring_to_ebcdic(env, jApplid);
     const int applidLength = strlen(applid);
 
-    printf("APPLID length: %d\n", applidLength);
-    printf("APPLID value: %s\n", applid);
-
     char *__ptr32 thliApplidLen = (char *__ptr32)(thli + THLIAPPLIDLEN);
     *thliApplidLen = applidLength;
 
@@ -111,8 +104,6 @@ JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_setApplid(JN
     memcpy(origApplid, thliApplid, 8);
     memcpy(thliApplid, applid, applidLength);
     free_if_not_null(applid);
-
-    printf("Orig APPLID value: %s\n", origApplid);
 
     /* A call to pthread_security_np causes that the value set above is correctly propagated */
     pthread_security_np(0, 0, 0, NULL, NULL, 0);

--- a/zowe-rest-api-commons-spring/zossrc/secur.c
+++ b/zowe-rest-api-commons-spring/zossrc/secur.c
@@ -86,8 +86,7 @@ JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_setApplid(JN
 
     if (memcmp("THLI", thli, 4) != 0)
     {
-        int rc = -2;
-        printf("Could not set APPLID: BPXYTHLI control block not found\b");
+        printf("Could not set APPLID: BPXYTHLI control block not found\n");
         return -1;
     }
 

--- a/zowe-rest-api-commons-spring/zossrc/secur.h
+++ b/zowe-rest-api-commons-spring/zossrc/secur.h
@@ -37,7 +37,15 @@ JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_removeSecuri
  * Signature: ()I
  */
 JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_getLastErrno2
-  (JNIEnv *env, jobject obj);
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     org_zowe_commons_zos_security_jni_Secur
+ * Method:    setApplid
+ * Signature: (Ljava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_org_zowe_commons_zos_security_jni_Secur_setApplid
+  (JNIEnv *, jobject, jstring);
 
 #ifdef __cplusplus
 }

--- a/zowe-rest-api-sample-spring/docs/zos-security.md
+++ b/zowe-rest-api-sample-spring/docs/zos-security.md
@@ -401,7 +401,8 @@ The PassTicket is used instead of the password in HTTP Basic Authorization heade
 
 The replay protection needs to be switched off if you need to use the PassTicket multiple times which you need in case of REST API service.
 
-The API service needs to be configured with the APPLID.
+The API service needs to be configured with the APPLID. The APPLID is a name of the application (up to 8 characters)
+that is used by security products to differentiate certain security operations (like PassTickets) between applications.
 
 This can be done using Spring configuration property `zowe.commons.security.saf.applid: ZOWEAPPL` that is usally set in the external `application.yml` file.
 


### PR DESCRIPTION
This PR makes possible to use PassTickets for authentication using HTTP Basic method.

More details are in the updated documentation.

The IBM Java PlatformUser.authentication does not have a parameter with the APPLID so it is set for each thread by native method `Secur.setApplid()`.