### PR TITLE
Use the value of JAVA_HOME in the environment instead of setting it in makefile

### DIFF
--- a/zowe-rest-api-commons-spring/zossrc/makefile
+++ b/zowe-rest-api-commons-spring/zossrc/makefile
@@ -39,8 +39,6 @@ MACLIBS=-ISYS1.MACLIB \
 
 MTL_HEADERS=-I/usr/include/metal
 
-JAVA_HOME := /usr/lpp/java/J8.0_64
-
 DLL_CPP_FLAGS=-W "c,lp64,langlvl(extended),dll,xplink,exportall" \
  -qsearch=$(JAVA_HOME)/include \
  -qsource \

--- a/zowe-rest-api-sample-spring/zossrc/makefile
+++ b/zowe-rest-api-sample-spring/zossrc/makefile
@@ -39,8 +39,6 @@ MACLIBS=-ISYS1.MACLIB \
 
 MTL_HEADERS=-I/usr/include/metal
 
-JAVA_HOME := /usr/lpp/java/J8.0_64
-
 DLL_CPP_FLAGS=-W "c,lp64,langlvl(extended),dll,xplink,exportall"\
  -qsearch=$(JAVA_HOME)/include \
  -qsource \


### PR DESCRIPTION
Fixes the problem that caused `zowe-api-dev zosbuild` failure:

```
"./wtojni.cpp", line 10.10: CCN5836 (S) The #include file <jni.h> is not found.
```

The `zowe-api-dev zosbuild` command has been setting JAVA_HOME environment variable but the makefiles have overridden it since `:=` works differently than in GNU makefile.

Reported by @ankitachdhr145

Signed-off-by: Petr Plavjanik <plavjanik@gmail.com>