### PR TITLE
update licenses to EPL-2.0 OR Apache-2.0

### DIFF
--- a/.licence/Apache-2.0-licence-header.txt
+++ b/.licence/Apache-2.0-licence-header.txt
@@ -1,7 +1,0 @@
-This program and the accompanying materials are made available under the terms of the
-Apache License, Version 2.0 which accompanies this distribution, and is available at
-http://www.apache.org/licenses/LICENSE-2.0
-
-SPDX-License-Identifier: Apache-2.0
-
-Copyright Contributors to the Zowe Project.

--- a/.licence/Apache-or-EPL-License-Header.txt
+++ b/.licence/Apache-or-EPL-License-Header.txt
@@ -1,0 +1,7 @@
+This program and the accompanying materials are made available and may be used, at your option, under either:
+* Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+Copyright Contributors to the Zowe Project.

--- a/.licence/EPL-2.0-licence-header.txt
+++ b/.licence/EPL-2.0-licence-header.txt
@@ -1,7 +1,0 @@
-This program and the accompanying materials are made available under the terms of the
-Eclipse Public License v2.0 which accompanies this distribution, and is available at
-https://www.eclipse.org/legal/epl-v20.html
-
-SPDX-License-Identifier: EPL-2.0
-
-Copyright Contributors to the Zowe Project.

--- a/LICENSE
+++ b/LICENSE
@@ -275,3 +275,207 @@ version(s), and exceptions or additional permissions here}."
   look for such a notice.
 
   You may add additional accurate notices of copyright ownership.
+
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/jarpatcher/build.gradle
+++ b/jarpatcher/build.gradle
@@ -40,7 +40,7 @@ jacocoTestReport.dependsOn test
 check.dependsOn jacocoTestReport
 
 license {
-    header rootProject.file('.licence/EPL-2.0-licence-header.txt')
+    header rootProject.file('.licence/Apache-or-EPL-License-Header.txt')
     ext.year = Calendar.getInstance().get(Calendar.YEAR)
     excludes(["**/*.yml", "**/*.json", "**/*.sh", "**/*.txt", "**/*.p12", "**/*.xml", "**/*.jsp", "**/*.html", "**/*.jks", "**/*.so", "**/*.md"])
     mapping {

--- a/jarpatcher/src/main/java/jarpatcher/JarPatcher.java
+++ b/jarpatcher/src/main/java/jarpatcher/JarPatcher.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/jarpatcher/src/test/java/jarpatcher/ArchiveDefinition.java
+++ b/jarpatcher/src/test/java/jarpatcher/ArchiveDefinition.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/jarpatcher/src/test/java/jarpatcher/JarPatcherTests.java
+++ b/jarpatcher/src/test/java/jarpatcher/JarPatcherTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/jarpatcher/src/test/java/jarpatcher/TestFile.java
+++ b/jarpatcher/src/test/java/jarpatcher/TestFile.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-api-dev/package.json
+++ b/zowe-api-dev/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "tslint -p test -t stylish",
-    "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme && cp -v ../jarpatcher/build/libs/jarpatcher.jar lib",
+    "prepack": "rm -rf lib && node scripts/updateLicense.js && tsc -b && oclif-dev manifest && oclif-dev readme && cp -v ../jarpatcher/build/libs/jarpatcher.jar lib",
     "prettier": "npx prettier --write \"src/**/*.ts\"",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif-dev readme && git add README.md"

--- a/zowe-api-dev/scripts/updateLicense.js
+++ b/zowe-api-dev/scripts/updateLicense.js
@@ -1,0 +1,51 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
+const fs = require("fs");
+
+// process all typescript files
+require("glob")("{__mocks__,src,gulp,__tests__,jenkins,scripts}{/**/*.js,/**/*.ts}", (globErr, filePaths) => {
+        if (globErr) {
+            throw globErr;
+        }
+        // turn the license file into a multi line comment
+        const desiredLineLength = 80;
+        let alreadyContainedCopyright = 0;
+        const header = "/*\n" + fs.readFileSync("../.licence/Apache-or-EPL-License-Header.txt").toString()
+                .split(/\r?\n/g).map((line) => {
+                    return `* ${line}`.trim();
+                })
+                .join(require("os").EOL) + require("os").EOL + "*/" +
+            require("os").EOL + require("os").EOL;
+        for (const filePath of filePaths) {
+            const file = fs.readFileSync(filePath);
+            let result = file.toString();
+            const resultLines = result.split(/\r?\n/g);
+            if (resultLines.join().indexOf(header.split(/\r?\n/g).join()) >= 0) {
+                alreadyContainedCopyright++;
+                continue; // already has copyright
+            }
+            const shebangPattern = require("shebang-regex");
+            let usedShebang = "";
+            result = result.replace(shebangPattern, function (fullMatch) {
+                usedShebang = fullMatch + "\n"; // save the shebang that was used, if any
+                return "";
+            });
+            // remove any existing copyright
+            // Be very, very careful messing with this regex. Regex is wonderful.
+            result = result.replace(/\/\*[\s\S]*?(License|SPDX)[\s\S]*?\*\/[\s\n]*/i, "");
+            result = header + result; // add the new header
+            result = usedShebang + result; // add the shebang back
+            fs.writeFileSync(filePath, result);
+        }
+        console.log("Ensured that %d files had copyright information" +
+            " (%d already did).", filePaths.length, alreadyContainedCopyright);
+    }
+);

--- a/zowe-api-dev/src/commands/config.ts
+++ b/zowe-api-dev/src/commands/config.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import { Command, flags } from "@oclif/command";
 import * as logSymbols from "log-symbols";
 import { IConfiguration, readConfiguration } from "../config";

--- a/zowe-api-dev/src/commands/deploy.ts
+++ b/zowe-api-dev/src/commands/deploy.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import { Command, flags } from "@oclif/command";
 import * as logSymbols from "log-symbols";
 import { readConfiguration } from "../config";

--- a/zowe-api-dev/src/commands/init.ts
+++ b/zowe-api-dev/src/commands/init.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import { Command, flags } from "@oclif/command";
 import * as Debug from "debug";
 import { existsSync, writeFileSync } from "fs";

--- a/zowe-api-dev/src/commands/start.ts
+++ b/zowe-api-dev/src/commands/start.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import { Command, flags } from "@oclif/command";
 import * as Debug from "debug";
 import { readFileSync, writeFileSync } from "fs";

--- a/zowe-api-dev/src/commands/status.ts
+++ b/zowe-api-dev/src/commands/status.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import { Command } from "@oclif/command";
 import * as Debug from "debug";
 import { clearLastJob, findJob, readLastJob, saveLastJob } from "../jes";

--- a/zowe-api-dev/src/commands/stop.ts
+++ b/zowe-api-dev/src/commands/stop.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import { Command } from "@oclif/command";
 import * as Debug from "debug";
 import { clearLastJob, findJob, IJob, readLastJob, saveLastJob } from "../jes";

--- a/zowe-api-dev/src/commands/zfs.ts
+++ b/zowe-api-dev/src/commands/zfs.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import { Command, flags } from "@oclif/command";
 import * as Debug from "debug";
 import * as logSymbols from "log-symbols";

--- a/zowe-api-dev/src/commands/zosbuild.ts
+++ b/zowe-api-dev/src/commands/zosbuild.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import { Command, flags } from "@oclif/command";
 import { execSync } from "child_process";
 import { existsSync, lstatSync, readdirSync } from "fs";

--- a/zowe-api-dev/src/config.ts
+++ b/zowe-api-dev/src/config.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import Command from "@oclif/command";
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";

--- a/zowe-api-dev/src/files.ts
+++ b/zowe-api-dev/src/files.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import Command from "@oclif/command";
 import { execSync } from 'child_process';
 import * as Debug from "debug";

--- a/zowe-api-dev/src/index.ts
+++ b/zowe-api-dev/src/index.ts
@@ -1,1 +1,11 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 export { run } from "@oclif/command";

--- a/zowe-api-dev/src/jes.ts
+++ b/zowe-api-dev/src/jes.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import * as Debug from "debug";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { zoweSync } from "./zowe";

--- a/zowe-api-dev/src/zowe.ts
+++ b/zowe-api-dev/src/zowe.ts
@@ -1,3 +1,13 @@
+/*
+* This program and the accompanying materials are made available and may be used, at your option, under either:
+* * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*/
+
 import { Command } from "@oclif/command";
 import { execSync } from "child_process";
 import * as Debug from "debug";

--- a/zowe-rest-api-commons-spring/build.gradle
+++ b/zowe-rest-api-commons-spring/build.gradle
@@ -16,7 +16,7 @@ ext {
 }
 
 license {
-    header rootProject.file('.licence/EPL-2.0-licence-header.txt')
+    header rootProject.file('.licence/Apache-or-EPL-License-Header.txt')
     ext.year = Calendar.getInstance().get(Calendar.YEAR)
     excludes(["**/*.yml", "**/*.json", "**/*.sh", "**/*.txt", "**/*.p12", "**/*.xml", "**/*.jsp", "**/*.html", "**/*.jks", "**/*.so", "**/*.md"])
     mapping {

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/AccentStrippingPatternLayerEncoder.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/AccentStrippingPatternLayerEncoder.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/UseridFilter.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/UseridFilter.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apidoc/ApiDocConstants.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apidoc/ApiDocConstants.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apidoc/BasePathProvider.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apidoc/BasePathProvider.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apiml/ApiMediationServiceConfigBean.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apiml/ApiMediationServiceConfigBean.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apiml/ApimlIntegrationFailureDetector.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apiml/ApimlIntegrationFailureDetector.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apiml/RegisterToApiLayer.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apiml/RegisterToApiLayer.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apiml/SslConfigBean.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/apiml/SslConfigBean.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/CommonsErrorService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/CommonsErrorService.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/DuplicateMessageException.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/DuplicateMessageException.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorMessage.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorMessage.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorMessageStorage.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorMessageStorage.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorMessages.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorMessages.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorService.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorServiceImpl.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/ErrorServiceImpl.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/MessageLoadException.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/error/MessageLoadException.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/ApiMessage.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/ApiMessage.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/BasicApiMessage.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/BasicApiMessage.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/BasicMessage.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/BasicMessage.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/Message.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/Message.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/MessageType.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/rest/response/MessageType.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/CustomRestExceptionHandler.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/CustomRestExceptionHandler.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/DefaultMessageSource.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/DefaultMessageSource.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/EnableEurekaLoggingTimerTask.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/EnableEurekaLoggingTimerTask.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/RestAuthenticationEntryPoint.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/RestAuthenticationEntryPoint.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/ServiceStartupEventHandler.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/ServiceStartupEventHandler.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/SpringContext.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/SpringContext.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/WebConfig.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/WebConfig.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/CsrfController.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/CsrfController.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/HttpsWebServerConfig.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/HttpsWebServerConfig.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/MethodSecurityConfig.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/MethodSecurityConfig.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/SafMethodSecurityExpressionHandler.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/SafMethodSecurityExpressionHandler.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/SafMethodSecurityExpressionRoot.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/SafMethodSecurityExpressionRoot.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/SafSecurityConfigurationProperties.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/spring/security/SafSecurityConfigurationProperties.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/CommonsNativeLibraries.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/CommonsNativeLibraries.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/LibExtractor.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/LibExtractor.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/LibLoader.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/LibLoader.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/NativeLibraries.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/NativeLibraries.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/ZosUtils.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/ZosUtils.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationException.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationException.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationProvider.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationProvider.java
@@ -1,3 +1,12 @@
+/*
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 
 /*
  * This program and the accompanying materials are made available under the terms of the

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationProvider.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationProvider.java
@@ -8,15 +8,6 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-/*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- */
 package org.zowe.commons.zos.security.authentication;
 
 import java.util.ArrayList;

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/jni/Secur.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/jni/Secur.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/MockPlatformAccessControl.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/MockPlatformAccessControl.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/MockPlatformUser.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/MockPlatformUser.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformAccessControl.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformAccessControl.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformAckErrno.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformAckErrno.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformClassFactory.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformClassFactory.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformErrno2.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformErrno2.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformErrorType.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformErrorType.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformPwdErrno.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformPwdErrno.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformReturned.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformReturned.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformThread.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformThread.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformTlsErrno.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformTlsErrno.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformUser.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/PlatformUser.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafConstants.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafConstants.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformAccessControl.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformAccessControl.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformClassFactory.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformClassFactory.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformError.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformError.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformThread.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformThread.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformUser.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafPlatformUser.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafUtils.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/platform/SafUtils.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/AccessControlError.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/AccessControlError.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/AccessControlService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/AccessControlService.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/DummyPlatformSecurityService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/DummyPlatformSecurityService.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/PlatformSecurityService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/PlatformSecurityService.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/SecurityRequestFailed.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/SecurityRequestFailed.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/ZosJniPlatformSecurityService.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/service/ZosJniPlatformSecurityService.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/thread/CallInThreadLevelSecurityEnvironmentByDaemon.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/thread/CallInThreadLevelSecurityEnvironmentByDaemon.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/thread/PlatformThreadLevelSecurity.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/thread/PlatformThreadLevelSecurity.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/thread/PlatformThreadLevelSecurityByDaemon.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/thread/PlatformThreadLevelSecurityByDaemon.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/thread/RunInThreadLevelSecurityEnvironmentByDaemon.java
+++ b/zowe-rest-api-commons-spring/src/main/java/org/zowe/commons/zos/security/thread/RunInThreadLevelSecurityEnvironmentByDaemon.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/main/resources/commons-messages_cs.properties
+++ b/zowe-rest-api-commons-spring/src/main/resources/commons-messages_cs.properties
@@ -1,9 +1,9 @@
 #
-# This program and the accompanying materials are made available under the terms of the
-# Eclipse Public License v2.0 which accompanies this distribution, and is available at
-# https://www.eclipse.org/legal/epl-v20.html
+# This program and the accompanying materials are made available and may be used, at your option, under either:
+# * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+# * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
-# SPDX-License-Identifier: EPL-2.0
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 #
 # Copyright Contributors to the Zowe Project.
 #

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/AccentStrippingPatternLayerEncoderTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/AccentStrippingPatternLayerEncoderTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/apiml/ApimlIntegrationFailureDetectorTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/apiml/ApimlIntegrationFailureDetectorTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/apiml/RegisterToApiLayerTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/apiml/RegisterToApiLayerTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/CommonsErrorServiceTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/CommonsErrorServiceTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorMessageStorageTest.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorMessageStorageTest.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorServiceImplTest.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/error/ErrorServiceImplTest.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/rest/response/BasicApiMessageTest.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/rest/response/BasicApiMessageTest.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/rest/response/BasicMessageTest.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/rest/response/BasicMessageTest.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/CustomRestExceptionHandlerTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/CustomRestExceptionHandlerTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/DefaultMessageSourceTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/DefaultMessageSourceTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/EnableEurekaLoggingTimerTaskTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/EnableEurekaLoggingTimerTaskTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/RestAuthenticationEntryPointTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/RestAuthenticationEntryPointTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/SpringContextTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/SpringContextTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/security/HttpsWebServerConfigTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/spring/security/HttpsWebServerConfigTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationProviderTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationProviderTests.java
@@ -1,3 +1,12 @@
+/*
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 
 /*
  * This program and the accompanying materials are made available under the terms of the

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationProviderTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/authentication/ZosAuthenticationProviderTests.java
@@ -8,15 +8,6 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-/*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- */
 package org.zowe.commons.zos.security.authentication;
 
 import static org.junit.Assert.assertEquals;

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/BadMockPlatformClassFactory.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/BadMockPlatformClassFactory.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/MockPlatformClassFactory.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/MockPlatformClassFactory.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/PlatformErnnoTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/PlatformErnnoTests.java
@@ -8,15 +8,6 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-/*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- */
 package org.zowe.commons.zos.security.platform;
 
 import static org.junit.Assert.assertEquals;

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/PlatformErnnoTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/PlatformErnnoTests.java
@@ -1,3 +1,12 @@
+/*
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 
 /*
  * This program and the accompanying materials are made available under the terms of the

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformAccessControlTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformAccessControlTests.java
@@ -1,3 +1,12 @@
+/*
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 
 /*
  * This program and the accompanying materials are made available under the terms of the

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformAccessControlTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformAccessControlTests.java
@@ -8,15 +8,6 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-/*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- */
 package org.zowe.commons.zos.security.platform;
 
 import static org.junit.Assert.assertNotNull;

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformUserTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformUserTests.java
@@ -1,3 +1,12 @@
+/*
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 
 /*
  * This program and the accompanying materials are made available under the terms of the

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformUserTests.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/platform/SafPlatformUserTests.java
@@ -8,25 +8,16 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-/*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- */
 package org.zowe.commons.zos.security.platform;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.zowe.commons.zos.security.platform.MockPlatformUser.VALID_PASSWORD;
-import static org.zowe.commons.zos.security.platform.MockPlatformUser.VALID_USERID;
 import static org.zowe.commons.zos.security.platform.MockPlatformUser.INVALID_PASSWORD;
 import static org.zowe.commons.zos.security.platform.MockPlatformUser.INVALID_USERID;
+import static org.zowe.commons.zos.security.platform.MockPlatformUser.VALID_PASSWORD;
+import static org.zowe.commons.zos.security.platform.MockPlatformUser.VALID_USERID;
 
 import org.junit.Test;
 

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/service/DummyPlatformSecurityServiceTest.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/service/DummyPlatformSecurityServiceTest.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/thread/PlatformThreadLevelSecurityByDaemonTest.java
+++ b/zowe-rest-api-commons-spring/src/test/java/org/zowe/commons/zos/security/thread/PlatformThreadLevelSecurityByDaemonTest.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-commons-spring/src/test/resources/test-messages_cs.properties
+++ b/zowe-rest-api-commons-spring/src/test/resources/test-messages_cs.properties
@@ -1,9 +1,9 @@
 #
-# This program and the accompanying materials are made available under the terms of the
-# Eclipse Public License v2.0 which accompanies this distribution, and is available at
-# https://www.eclipse.org/legal/epl-v20.html
+# This program and the accompanying materials are made available and may be used, at your option, under either:
+# * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+# * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
-# SPDX-License-Identifier: EPL-2.0
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 #
 # Copyright Contributors to the Zowe Project.
 #

--- a/zowe-rest-api-commons-spring/zossrc/makefile
+++ b/zowe-rest-api-commons-spring/zossrc/makefile
@@ -1,12 +1,12 @@
 # makefile boilerplate to build the JNI implementation (C++), metal C code, and
 # bind into a "shared object" called at REST API runtime via the /wto endpoint
 #
-# This program and the accompanying materials are made available under the terms of the
-# Eclipse Public License v2.0 which accompanies this distribution, and is available at
-# https://www.eclipse.org/legal/epl-v20.html
-#
-# SPDX-License-Identifier: EPL-2.0
-#
+# This program and the accompanying materials are made available and may be used, at your option, under either:
+# * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+# * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+# 
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+# 
 # Copyright Contributors to the Zowe Project.
 
 CXX=xlc++

--- a/zowe-rest-api-sample-spring/.licence/Apache-2.0-licence-header.txt
+++ b/zowe-rest-api-sample-spring/.licence/Apache-2.0-licence-header.txt
@@ -1,7 +1,0 @@
-This program and the accompanying materials are made available under the terms of the
-Apache License, Version 2.0 which accompanies this distribution, and is available at
-http://www.apache.org/licenses/LICENSE-2.0
-
-SPDX-License-Identifier: Apache-2.0
-
-Copyright Contributors to the Zowe Project.

--- a/zowe-rest-api-sample-spring/.licence/Apache-or-EPL-License-Header.txt
+++ b/zowe-rest-api-sample-spring/.licence/Apache-or-EPL-License-Header.txt
@@ -1,0 +1,7 @@
+This program and the accompanying materials are made available and may be used, at your option, under either:
+* Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+* Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+Copyright Contributors to the Zowe Project.

--- a/zowe-rest-api-sample-spring/build.gradle
+++ b/zowe-rest-api-sample-spring/build.gradle
@@ -93,7 +93,7 @@ jacocoTestReport.dependsOn test
 check.dependsOn jacocoTestReport
 
 license {
-    header rootProject.file('.licence/Apache-2.0-licence-header.txt')
+    header rootProject.file('.licence/Apache-or-EPL-License-Header.txt')
     ext.year = Calendar.getInstance().get(Calendar.YEAR)
     excludes(["**/*.yml", "**/*.json", "**/*.sh", "**/*.txt", "**/*.p12", "**/*.xml", "**/*.jsp", "**/*.html", "**/*.jks", "**/*.so", "**/*.md"])
     mapping {

--- a/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/greeting/GreetingControllerIntegrationTests.java
+++ b/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/greeting/GreetingControllerIntegrationTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/security/SecurityContextControllerIntegrationTests.java
+++ b/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/security/SecurityContextControllerIntegrationTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/test/IntegrationTests.java
+++ b/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/test/IntegrationTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/test/ServiceUnderTest.java
+++ b/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/test/ServiceUnderTest.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/wto/WtoControllerIntegrationTests.java
+++ b/zowe-rest-api-sample-spring/src/integrationTest/java/org/zowe/sample/apiservice/wto/WtoControllerIntegrationTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/AppNativeLibraries.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/AppNativeLibraries.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/LibsExtractor.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/LibsExtractor.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/ZoweApiServiceApplication.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/ZoweApiServiceApplication.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/apidoc/SwaggerConfig.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/apidoc/SwaggerConfig.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/ApplicationConfig.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/ApplicationConfig.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/WebSecurityConfig.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/config/WebSecurityConfig.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/EmptyNameError.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/EmptyNameError.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/Greeting.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/Greeting.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingController.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingController.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingControllerExceptionHandler.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingControllerExceptionHandler.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingSettings.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/greeting/GreetingSettings.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/security/SecurityContextController.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/security/SecurityContextController.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/wto/OffZosWto.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/wto/OffZosWto.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/wto/Wto.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/wto/Wto.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/wto/WtoController.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/wto/WtoController.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/wto/WtoResponse.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/wto/WtoResponse.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/wto/ZosWto.java
+++ b/zowe-rest-api-sample-spring/src/main/java/org/zowe/sample/apiservice/wto/ZosWto.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/main/resources/messages.properties
+++ b/zowe-rest-api-sample-spring/src/main/resources/messages.properties
@@ -1,9 +1,9 @@
 #
-# This program and the accompanying materials are made available under the terms of the
-# Apache License, Version 2.0 which accompanies this distribution, and is available at
-# http://www.apache.org/licenses/LICENSE-2.0
+# This program and the accompanying materials are made available and may be used, at your option, under either:
+# * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+# * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 #
 # Copyright Contributors to the Zowe Project.
 #

--- a/zowe-rest-api-sample-spring/src/main/resources/messages_cs.properties
+++ b/zowe-rest-api-sample-spring/src/main/resources/messages_cs.properties
@@ -1,9 +1,9 @@
 #
-# This program and the accompanying materials are made available under the terms of the
-# Apache License, Version 2.0 which accompanies this distribution, and is available at
-# http://www.apache.org/licenses/LICENSE-2.0
+# This program and the accompanying materials are made available and may be used, at your option, under either:
+# * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+# * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 #
 # Copyright Contributors to the Zowe Project.
 #

--- a/zowe-rest-api-sample-spring/src/main/resources/messages_es.properties
+++ b/zowe-rest-api-sample-spring/src/main/resources/messages_es.properties
@@ -1,9 +1,9 @@
 #
-# This program and the accompanying materials are made available under the terms of the
-# Apache License, Version 2.0 which accompanies this distribution, and is available at
-# http://www.apache.org/licenses/LICENSE-2.0
+# This program and the accompanying materials are made available and may be used, at your option, under either:
+# * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+# * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 #
 # Copyright Contributors to the Zowe Project.
 #

--- a/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/TestUtils.java
+++ b/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/TestUtils.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/ZoweApiServiceApplicationTests.java
+++ b/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/ZoweApiServiceApplicationTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/greeting/GreetingControllerTests.java
+++ b/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/greeting/GreetingControllerTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/security/SecurityContextControllerTests.java
+++ b/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/security/SecurityContextControllerTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/wto/WtoControllerTests.java
+++ b/zowe-rest-api-sample-spring/src/test/java/org/zowe/sample/apiservice/wto/WtoControllerTests.java
@@ -1,9 +1,9 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Apache License, Version 2.0 which accompanies this distribution, and is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *
  * Copyright Contributors to the Zowe Project.
  */

--- a/zowe-rest-api-sample-spring/zossrc/makefile
+++ b/zowe-rest-api-sample-spring/zossrc/makefile
@@ -1,12 +1,12 @@
 # makefile boilerplate to build the JNI implementation (C++), metal C code, and
 # bind into a "shared object" called at REST API runtime via the /wto endpoint
 #
-# This program and the accompanying materials are made available under the terms of the
-# Eclipse Public License v2.0 which accompanies this distribution, and is available at
-# https://www.eclipse.org/legal/epl-v20.html
-#
-# SPDX-License-Identifier: EPL-2.0
-#
+# This program and the accompanying materials are made available and may be used, at your option, under either:
+# * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+# * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+# 
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+# 
 # Copyright Contributors to the Zowe Project.
 
 CXX=xlc++

--- a/zowe-rest-api-sample-spring/zossrc/wto.h
+++ b/zowe-rest-api-sample-spring/zossrc/wto.h
@@ -6,12 +6,12 @@
  */
 
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * 
  * Copyright Contributors to the Zowe Project.
  */
 

--- a/zowe-rest-api-sample-spring/zossrc/wtoexec.c
+++ b/zowe-rest-api-sample-spring/zossrc/wtoexec.c
@@ -1,10 +1,10 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * 
  * Copyright Contributors to the Zowe Project.
  */
 #include "wtoexec.h"

--- a/zowe-rest-api-sample-spring/zossrc/wtoexec.h
+++ b/zowe-rest-api-sample-spring/zossrc/wtoexec.h
@@ -2,12 +2,12 @@
 #define WTOEXEC_H
 
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * 
  * Copyright Contributors to the Zowe Project.
  */
 

--- a/zowe-rest-api-sample-spring/zossrc/wtojni.cpp
+++ b/zowe-rest-api-sample-spring/zossrc/wtojni.cpp
@@ -1,10 +1,10 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * 
  * Copyright Contributors to the Zowe Project.
  */
 #include <jni.h>


### PR DESCRIPTION
Signed-off-by: MarkAckert <mark.ackert@broadcom.com>

To complete work started in #71 and implement license guidance from the ZLC here: https://github.com/zowe/zlc/blob/master/process/LicenseAndCopyrightGuidance.md . 

The license file is updated to include both EPL 2.0 and Apache 2.0 licenses. SPDX header has changed to be EPL or Apache 2.0.

SPDX headers have also been added to the zowe-api-dev project. 
