### PR TITLE
Upload subdirectories in zosbuild

### DIFF
--- a/zowe-api-dev/src/commands/zosbuild.ts
+++ b/zowe-api-dev/src/commands/zosbuild.ts
@@ -70,7 +70,9 @@ function uploadDir(dir: string, zosDir: string, profileName: string, command: Co
         files.forEach(file => {
             const sourceFile = `${dir}/${file}`;
             const targetFile = `${zosDir}/${file}`;
-            if (force || !isFileSame(sourceFile, targetFile, profileName)) {
+            if (lstatSync(sourceFile).isDirectory()) {
+                uploadedFiles += uploadDir(sourceFile, targetFile, profileName, command, force);
+            } else if (force || !isFileSame(sourceFile, targetFile, profileName)) {
                 uploadedFiles += 1;
                 if (uploadedFiles === 1) {
                     execSshCommandWithDefaultEnvCwd(`mkdir -p ${zosDir}`);


### PR DESCRIPTION
A small enhancement that uploads all subdirectories in `zosbuild` command

Signed-off-by: Petr Plavjanik <plavjanik@gmail.com>