### PR TITLE
Fix transferFiles function to process multiple files correctly

### DIFF
--- a/zowe-api-dev/src/files.ts
+++ b/zowe-api-dev/src/files.ts
@@ -97,7 +97,7 @@ export function transferFiles(
             const zosFileExists = !force && zosExistsSync(zosFile);
             if (!force && zosFileExists && isFileSame(file, zosFile, userConfig.zoweProfileName)) {
                 command.log(`${file} has not changed`)
-                return;
+                continue;
             }
             const oldFile = cachedOldFilePath(zosFile, userConfig.zoweProfileName);
             if (!force && file.endsWith(".jar") && existsSync(oldFile) && zosFileExists) {


### PR DESCRIPTION
Fix a bug where after first file in {files} is the same as already uploaded file, the processing ends and the other files don't get evaluated and uploaded.